### PR TITLE
[DraftPR] ユーザーが記事によって改行のサイズを調整できる

### DIFF
--- a/src/features/common/markdown-styles/ shared-markdown-styles.ts
+++ b/src/features/common/markdown-styles/ shared-markdown-styles.ts
@@ -16,7 +16,12 @@ export const sharedMarkdownStyles = (theme: Theme) => ({
     pointerEvents: "none"
   },
   "& .ProseMirror": {
-    outline: "none"
+    outline: "none",
+    // TODO: これをtrueだった時に適用させる
+    "& > *": {
+      marginTop: "0.7em !important",
+      marginBottom: "0.7em !important"
+    }
   },
   "&": {
     "&:first-of-type": {

--- a/src/features/common/post-form/ReflectionPostForm.tsx
+++ b/src/features/common/post-form/ReflectionPostForm.tsx
@@ -106,38 +106,43 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
       <Box
         component={"header"}
         position={"fixed"}
-        top={{ xs: 0, md: 25 }}
+        top={{ xs: 0, md: 24 }}
         right={{ xs: 0, md: 35 }}
         bgcolor={{ xs: "white", md: "transparent" }}
-        width={{ xs: "100%", md: "auto" }}
+        width={{ xs: "100%", md: "96%" }}
         zIndex={1}
       >
         <Box
           display={"flex"}
-          justifyContent={"flex-end"}
+          justifyContent={"space-between"}
+          alignItems={"center"}
           px={{ xs: 1.5, md: 0 }}
           py={{ xs: 1, md: 0 }}
           boxShadow={{ xs: "0px 0.7px 1px rgba(0, 0, 0, 0.1)", md: "none" }}
         >
-          <MarkdownSupportPopupAreaContainer />
-          <ReflectionTemplatePopupAreaContainer
-            onInsertTemplate={handleInsertTemplate}
-            onClearContent={handleClearContent}
-            reflectionTemplateType={REFLECTION_TEMPLATES}
-          />
-          <Controller
-            name="isPublic"
-            control={control}
-            render={({ field }) => (
-              <PublishSettingPopupAreaContainer
-                value={field.value}
-                onChange={field.onChange}
-              />
-            )}
-          />
-          <Button type="submit" disabled={isSubmitting || isSubmitSuccessful}>
-            {isSubmitting || isSubmitSuccessful ? "投稿中..." : "投稿する"}
-          </Button>
+          <Box display={"flex"}>
+            <MarkdownSupportPopupAreaContainer />
+          </Box>
+          <Box display={"flex"}>
+            <ReflectionTemplatePopupAreaContainer
+              onInsertTemplate={handleInsertTemplate}
+              onClearContent={handleClearContent}
+              reflectionTemplateType={REFLECTION_TEMPLATES}
+            />
+            <Controller
+              name="isPublic"
+              control={control}
+              render={({ field }) => (
+                <PublishSettingPopupAreaContainer
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+            <Button type="submit" disabled={isSubmitting || isSubmitSuccessful}>
+              {isSubmitting || isSubmitSuccessful ? "投稿中..." : "投稿する"}
+            </Button>
+          </Box>
         </Box>
         {isSmallScreen && (
           <Box px={1.5} py={0.8} boxShadow={"0px 0.7px 1px rgba(0, 0, 0, 0.1)"}>

--- a/src/features/routes/post/popup/markdown-support/MarkdownSupportPopupArea.tsx
+++ b/src/features/routes/post/popup/markdown-support/MarkdownSupportPopupArea.tsx
@@ -36,7 +36,7 @@ const MarkdownSupportPopupArea: React.FC<MarkdownSupportPopupAreaProps> = ({
     <Box position={"relative"} display={"flex"} alignItems={"center"}>
       <Tooltip
         title={<Typography fontSize={13}>書き方ガイドはこちら</Typography>}
-        placement={"bottom"}
+        placement={"bottom-start"}
         open={showInitialTooltip}
         arrow
         slotProps={{


### PR DESCRIPTION
## ユーザーFB
改行が大きすぎてかきたいフォーマットで書けない時がある

## 残タスク
- reflectionテーブルにデフォルトfalseでマイグレ
- trueだった時に改行を小さくする設定
- 改行サイズボタンを投稿ボタンに設置
  - PC、スマホともに未対応