### PR TITLE
SelectionHeaderを作成し、page.clientの肥大化を防ぐ

### DIFF
--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -61,7 +61,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   folders
 }) => {
   const [isLoading, setIsLoading] = useState(false);
-  const [isSelectionMode, setIsSelectionMode] = useState(false);
+  const [isSelectMode, setIsSelectMode] = useState(false);
   const [selectedReflections, setSelectedReflections] = useState<string[]>([]);
   const router = useRouter();
   const pathname = usePathname();
@@ -89,7 +89,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
 
   const handleSelectMode = (folderUUID: string) => {
     router.push(pathname);
-    setIsSelectionMode(true);
+    setIsSelectMode(true);
     setSelectedFolderUUID(folderUUID);
   };
 
@@ -104,7 +104,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   };
 
   const handleCancelSelectMode = () => {
-    setIsSelectionMode(false);
+    setIsSelectMode(false);
     setSelectedReflections([]);
     setSelectedFolderUUID("");
   };
@@ -123,7 +123,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
     }
 
     setFolders(updatedFolders);
-    setIsSelectionMode(false);
+    setIsSelectMode(false);
     setSelectedReflections([]);
     setIsLoading(false);
     router.push(`/${username}?folder=${selectedFolderUUID}`);
@@ -211,7 +211,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
               username={username}
               reflections={reflections}
               isCurrentUser={isCurrentUser}
-              isSelectMode={isSelectionMode}
+              isSelectMode={isSelectMode}
               isSelected={(reflectionCUID) =>
                 selectedReflections.includes(reflectionCUID)
               }

--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -1,9 +1,7 @@
 "use client";
 import { useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import FolderIcon from "@mui/icons-material/Folder";
-import TagIcon from "@mui/icons-material/Tag";
-import { Box, Typography, useMediaQuery } from "@mui/material";
+import { Box, useMediaQuery } from "@mui/material";
 import type { ReflectionsCount } from "@/src/api/reflections-count-api";
 import type { TagType } from "@/src/hooks/reflection-tag/useExtractTrueTags";
 import type { User } from "@prisma/client";
@@ -14,7 +12,7 @@ import {
   type Reflection,
   type ReflectionTagCountList
 } from "@/src/api/reflection-api";
-import { Button, PostNavigationButton } from "@/src/components/button";
+import { PostNavigationButton } from "@/src/components/button";
 import {
   ArrowPagination,
   NumberedPagination
@@ -24,6 +22,7 @@ import { SearchBar } from "@/src/features/common/search-bar";
 import ReflectionCardListArea from "@/src/features/routes/reflection-list/card-list/ReflectionCardListArea";
 import { GoodJobModal } from "@/src/features/routes/reflection-list/modal";
 import UserProfileArea from "@/src/features/routes/reflection-list/profile/UserProfileArea";
+import { SelectionHeader } from "@/src/features/routes/reflection-list/selection-header/SelectionHeader";
 import { Sidebar } from "@/src/features/routes/reflection-list/sidebar";
 import { FolderInitializer } from "@/src/features/routes/reflection-list/sidebar/FolderInitializer";
 import { usePagination } from "@/src/hooks/reflection/usePagination";
@@ -129,6 +128,10 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
     setIsLoading(false);
     router.push(`/${username}?folder=${selectedFolderUUID}`);
   };
+  const isFolderSelected = foldersState.some(
+    (f) => f.folderUUID === selectedFolderUUID
+  );
+  const disableAdd = selectedReflections.length === 0 || isLoading;
 
   const isCurrentUser = currentUsername === username;
   const isModalOpen = searchParams.get("status") === "posted";
@@ -186,49 +189,15 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
             onTagChange={handleTagChange}
           />
         )}
-        <Box
-          height={32}
-          mx={3}
-          my={1}
-          letterSpacing={0.8}
-          display={"flex"}
-          alignItems={"center"}
-          justifyContent={"space-between"}
-        >
-          {selectedInfo && (
-            <Box display={"flex"} alignItems={"center"}>
-              {foldersState.some((f) => f.folderUUID === selectedFolderUUID) ? (
-                <FolderIcon
-                  fontSize="small"
-                  sx={{ color: theme.palette.grey[500], mr: "4px" }}
-                />
-              ) : (
-                <TagIcon
-                  fontSize="small"
-                  sx={{ color: theme.palette.grey[500], mr: "4px" }}
-                />
-              )}
-              <Typography component={"span"} fontWeight={550}>
-                {selectedInfo.name}
-              </Typography>
-              <Typography>{`　${selectedInfo.count}件`}</Typography>
-            </Box>
-          )}
-          {isSelectionMode && isPCScreen && (
-            <Box display={"flex"} justifyContent={"right"} gap={1}>
-              <Button sx={button} onClick={handleCancelSelectMode}>
-                キャンセル
-              </Button>
-              <Button
-                sx={{ ...button, color: theme.palette.primary.light }}
-                onClick={handleAddReflectionToFolder}
-                disabled={selectedFolderUUID.length === 0 || isLoading}
-              >
-                追加
-              </Button>
-            </Box>
-          )}
-        </Box>
+        <SelectionHeader
+          selectedInfo={selectedInfo}
+          isFolderSelected={isFolderSelected}
+          isSelectMode={isSelectMode}
+          isPCScreen={isPCScreen}
+          onCancel={handleCancelSelectMode}
+          onAdd={handleAddReflectionToFolder}
+          disableAdd={disableAdd}
+        />
         {reflections.length === 0 ? (
           <EmptyReflection />
         ) : (
@@ -278,12 +247,3 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
 };
 
 export default UserReflectionListPage;
-
-const button = {
-  fontSize: 13.5,
-  p: "3px 6px",
-  letterSpacing: 0.8,
-  borderRadius: 2,
-  border: "1px solid #DCDFE3",
-  backgroundColor: "white"
-};

--- a/src/features/routes/reflection-list/selection-header/SelectionHeader.tsx
+++ b/src/features/routes/reflection-list/selection-header/SelectionHeader.tsx
@@ -1,0 +1,76 @@
+import FolderIcon from "@mui/icons-material/Folder";
+import TagIcon from "@mui/icons-material/Tag";
+import { Box, Typography, Button } from "@mui/material";
+import { theme } from "@/src/utils/theme";
+
+type SelectionHeaderProps = {
+  selectedInfo: { name: string; count: number } | null;
+  isFolderSelected: boolean;
+  isSelectMode: boolean;
+  isPCScreen: boolean;
+  onCancel: () => void;
+  onAdd: () => void;
+  disableAdd: boolean;
+};
+
+// MEMO: サイドバーで選択したフォルダ、タグの情報を表示。一括追加時のボタンも表示
+export const SelectionHeader: React.FC<SelectionHeaderProps> = ({
+  selectedInfo,
+  isSelectMode,
+  isPCScreen,
+  onCancel,
+  onAdd,
+  isFolderSelected,
+  disableAdd
+}) => {
+  return (
+    <Box
+      height={32}
+      mx={3}
+      my={1}
+      letterSpacing={0.8}
+      display={"flex"}
+      alignItems={"center"}
+      justifyContent={"space-between"}
+    >
+      {selectedInfo && (
+        <Box display={"flex"} alignItems={"center"}>
+          {isFolderSelected ? <FolderIcon sx={icon} /> : <TagIcon sx={icon} />}
+          <Typography component="span" fontWeight={550}>
+            {selectedInfo.name}
+          </Typography>
+          <Typography>{`　${selectedInfo.count}件`}</Typography>
+        </Box>
+      )}
+      {isSelectMode && isPCScreen && (
+        <Box display={"flex"} justifyContent={"right"} gap={1}>
+          <Button sx={button} onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button
+            sx={{ ...button, color: theme.palette.primary.light }}
+            onClick={onAdd}
+            disabled={disableAdd}
+          >
+            追加
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const icon = {
+  fontSize: "small",
+  color: theme.palette.grey[500],
+  mr: "4px"
+};
+
+const button = {
+  fontSize: 13.5,
+  p: "3px 6px",
+  letterSpacing: 0.8,
+  borderRadius: 2,
+  border: "1px solid #DCDFE3",
+  backgroundColor: "white"
+};

--- a/src/features/routes/reflection-list/selection-header/SelectionHeader.tsx
+++ b/src/features/routes/reflection-list/selection-header/SelectionHeader.tsx
@@ -1,6 +1,7 @@
 import FolderIcon from "@mui/icons-material/Folder";
 import TagIcon from "@mui/icons-material/Tag";
-import { Box, Typography, Button } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import { Button } from "@/src/components/button";
 import { theme } from "@/src/utils/theme";
 
 type SelectionHeaderProps = {


### PR DESCRIPTION
## 目的
page.clientの肥大化を防ぐ

## 見て欲しい観点
- それぞれの命名
  - 以下の画像の部分の良いコンポーネント名がそこまで思いつかなかった
  - 「選択した時のヘッダー」という意味をこめた
  - とはいえわかりにくいかもなのでコメントで残した
<img width="822" alt="スクリーンショット 2025-02-11 18 25 47" src="https://github.com/user-attachments/assets/13dcf475-08f8-4718-971b-d9bda1923985" />
