### PR TITLE
フォルダ作成時、 スマホとPCの新規作成の処理の流れを変える

### DIFF
--- a/src/components/alert/ErrorMessage.tsx
+++ b/src/components/alert/ErrorMessage.tsx
@@ -6,7 +6,7 @@ type ErrorMessageProps = {
 
 export const ErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => {
   return message ? (
-    <Typography color="error" variant="body2">
+    <Typography color="error" fontSize={12}>
       {message}
     </Typography>
   ) : null;

--- a/src/components/alert/ErrorMessage.tsx
+++ b/src/components/alert/ErrorMessage.tsx
@@ -1,12 +1,14 @@
 import { Typography } from "@mui/material";
+import type { SxProps } from "@mui/material";
 
 type ErrorMessageProps = {
   message: string | undefined;
+  sx?: SxProps;
 };
 
-export const ErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => {
+export const ErrorMessage: React.FC<ErrorMessageProps> = ({ message, sx }) => {
   return message ? (
-    <Typography color="error" fontSize={12}>
+    <Typography color="error" fontSize={12} sx={sx}>
       {message}
     </Typography>
   ) : null;

--- a/src/features/routes/reflection-list/sidebar/CreateFolderField.tsx
+++ b/src/features/routes/reflection-list/sidebar/CreateFolderField.tsx
@@ -44,7 +44,9 @@ export const CreateFolderField = ({
           <Box
             component="form"
             onSubmit={handleFolderSubmit}
-            sx={{ display: "flex", alignItems: "center", gap: 1 }}
+            display={"flex"}
+            alignItems={"center"}
+            gap={1}
           >
             <Controller
               name="name"

--- a/src/features/routes/reflection-list/sidebar/CreateFolderField.tsx
+++ b/src/features/routes/reflection-list/sidebar/CreateFolderField.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Controller } from "react-hook-form";
 import AddIcon from "@mui/icons-material/Add";
 import { Box, TextField, Typography, useMediaQuery } from "@mui/material";
+import { ErrorMessage } from "@/src/components/alert";
 import { Button } from "@/src/components/button";
 import { useCreateFolder } from "@/src/hooks/folder/useCreateFolder";
 import { theme } from "@/src/utils/theme";
@@ -82,6 +83,12 @@ export const CreateFolderField = ({
               </Button>
             )}
           </Box>
+          {errors?.name?.message && (
+            <ErrorMessage
+              message={errors.name.message}
+              sx={{ mx: { lg: 1.5 }, display: "block" }}
+            />
+          )}
         </>
       ) : (
         <Box

--- a/src/features/routes/reflection-list/sidebar/CreateFolderField.tsx
+++ b/src/features/routes/reflection-list/sidebar/CreateFolderField.tsx
@@ -56,13 +56,12 @@ export const CreateFolderField = ({
                   size="small"
                   placeholder="フォルダ名"
                   error={Boolean(errors?.name)}
-                  helperText={errors?.name?.message}
                   onBlur={() => setIsEditing(false)}
                   onKeyDown={isMobile ? handleKeyDown : undefined}
                   sx={{
                     width: "100%",
                     fontSize: 14,
-                    mx: 1.5,
+                    mx: { lg: 1.5 },
                     "& .MuiInputBase-root": {
                       fontSize: 14,
                       height: 30
@@ -75,6 +74,7 @@ export const CreateFolderField = ({
               <Button
                 onClick={handleFolderSubmit}
                 onMouseDown={(e) => e.preventDefault()}
+                sx={button}
               >
                 作成
               </Button>
@@ -104,4 +104,13 @@ export const CreateFolderField = ({
       )}
     </Box>
   );
+};
+
+const button = {
+  fontSize: 13.5,
+  p: "3px",
+  letterSpacing: 0.8,
+  borderRadius: 2,
+  border: "1px solid #DCDFE3",
+  backgroundColor: "white"
 };

--- a/src/features/routes/reflection-list/sidebar/CreateFolderField.tsx
+++ b/src/features/routes/reflection-list/sidebar/CreateFolderField.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Controller } from "react-hook-form";
 import AddIcon from "@mui/icons-material/Add";
-import { Box, TextField, Typography } from "@mui/material";
+import { Box, TextField, Typography, useMediaQuery } from "@mui/material";
+import { Button } from "@/src/components/button";
 import { useCreateFolder } from "@/src/hooks/folder/useCreateFolder";
 import { theme } from "@/src/utils/theme";
 
@@ -15,6 +16,7 @@ export const CreateFolderField = ({
   onRefetch
 }: CreateFolderFieldProps) => {
   const [isEditing, setIsEditing] = useState(false);
+  const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
 
   const createFolderHook = useCreateFolder({
     username,
@@ -23,6 +25,13 @@ export const CreateFolderField = ({
   });
   if (!createFolderHook) return null;
   const { control, errors, onSubmit } = createFolderHook;
+
+  // MEMO: スマホのEnterキー(改行ボタン等)で送信されてしまうのを防ぐ
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+    }
+  };
 
   const handleFolderSubmit = async (e: React.FormEvent) => {
     await onSubmit(e);
@@ -49,6 +58,7 @@ export const CreateFolderField = ({
                   error={Boolean(errors?.name)}
                   helperText={errors?.name?.message}
                   onBlur={() => setIsEditing(false)}
+                  onKeyDown={isMobile ? handleKeyDown : undefined}
                   sx={{
                     width: "100%",
                     fontSize: 14,
@@ -61,6 +71,14 @@ export const CreateFolderField = ({
                 />
               )}
             />
+            {isMobile && (
+              <Button
+                onClick={handleFolderSubmit}
+                onMouseDown={(e) => e.preventDefault()}
+              >
+                作成
+              </Button>
+            )}
           </Box>
         </>
       ) : (

--- a/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
+++ b/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
@@ -56,6 +56,10 @@ export const FolderKebabMenuButton: React.FC<FolderKebabMenuButtonProps> = ({
         anchorEl={anchorEl}
         transition
         placement={"bottom-end"}
+        sx={{
+          position: "relative",
+          zIndex: 10
+        }}
       >
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>

--- a/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButtonContainer.tsx
+++ b/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButtonContainer.tsx
@@ -68,7 +68,6 @@ export const FolderKebabButtonPopupContainer: React.FC<
           left={0}
           width="100vw"
           height="100vh"
-          zIndex={3}
         />
       )}
       <FolderKebabMenuButton


### PR DESCRIPTION
## 動作確認
https://github.com/user-attachments/assets/42677b75-4290-4159-afb4-7c45e065204e

## やったこと
- ErrorMessageを使ってエラー文を出す
  - sxを使えるようにし、文字の大きさも小さくした
- スマホ時はエンター等で作成できないようにし、作成ボタンを用意
- 別ブランチの変更により、ケバブボタンが出ないバグが起きていたので直しておく