### PR TITLE
disablePortalを追加し無駄なレンダリングを防ぎ軽いバグを解消する

### DIFF
--- a/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
+++ b/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
@@ -52,6 +52,7 @@ export const FolderKebabMenuButton: React.FC<FolderKebabMenuButtonProps> = ({
         />
       </Box>
       <Popper
+        disablePortal
         open={open}
         anchorEl={anchorEl}
         transition
@@ -63,7 +64,12 @@ export const FolderKebabMenuButton: React.FC<FolderKebabMenuButtonProps> = ({
       >
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
-            <Box boxShadow={1} borderRadius={2.5} bgcolor={"white"}>
+            <Box
+              boxShadow={1}
+              borderRadius={2.5}
+              bgcolor={"white"}
+              minWidth={200}
+            >
               <PopupButton
                 text={"投稿をフォルダに追加"}
                 src={"/add-to-folder.svg"}


### PR DESCRIPTION
## みて欲しいところ
以下動画の上2つ。画面左上にポップアップがもう一つレンダリングされているバグ

## 今後
別のポップアップもレンダリングが全てこうなっている可能性があり、将来的にリフティの負債になりかねないので @sora-00 とかにお願いしてもいいかなと思っている。
注意点としては、ポップアップのwidthが急に縮まるのでこのコミットのように`minWidth`等を設定してあげる必要がある

## 現状のレンダリング

https://github.com/user-attachments/assets/0842df91-2fa0-4f40-858f-cce7373b914c

## 実装後のレンダリング

https://github.com/user-attachments/assets/2499af84-e0b1-4e22-b1be-a07ddeb220ca


## 現状のバグ
- ポップアップが消える瞬間に0,5秒くらい画面の左上にポップアップが出て消える

https://github.com/user-attachments/assets/ea702f3a-d47c-4194-b85f-4c88398bf2a9

## バグ解消後
- 上記の解消

https://github.com/user-attachments/assets/8d687870-ad42-4f79-bd6e-f982cd3d6173


