### PR TITLE
モバイルはケバブボタンを常時設定し、一括追加もできるようにする

### DIFF
--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -65,7 +65,6 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isLargeScreen = useMediaQuery(theme.breakpoints.up("sm"));
-  const isPCScreen = useMediaQuery(theme.breakpoints.up("lg"));
 
   const { handlePageChange } = usePagination();
 
@@ -174,7 +173,6 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
           selectedInfo={selectedInfo}
           isFolderSelected={isFolderSelected}
           isSelectMode={isSelectMode}
-          isPCScreen={isPCScreen}
           onCancel={handleCancelSelectMode}
           onAdd={handleAddReflectionToFolder}
           disableAdd={disableAdd}

--- a/src/features/routes/reflection-list/selection-header/SelectionHeader.tsx
+++ b/src/features/routes/reflection-list/selection-header/SelectionHeader.tsx
@@ -8,7 +8,6 @@ type SelectionHeaderProps = {
   selectedInfo: { name: string; count: number } | null;
   isFolderSelected: boolean;
   isSelectMode: boolean;
-  isPCScreen: boolean;
   onCancel: () => void;
   onAdd: () => void;
   disableAdd: boolean;
@@ -18,7 +17,6 @@ type SelectionHeaderProps = {
 export const SelectionHeader: React.FC<SelectionHeaderProps> = ({
   selectedInfo,
   isSelectMode,
-  isPCScreen,
   onCancel,
   onAdd,
   isFolderSelected,
@@ -43,7 +41,7 @@ export const SelectionHeader: React.FC<SelectionHeaderProps> = ({
           <Typography>{`　${selectedInfo.count}件`}</Typography>
         </Box>
       )}
-      {isSelectMode && isPCScreen && (
+      {isSelectMode && (
         <Box display={"flex"} justifyContent={"right"} gap={1}>
           <Button sx={button} onClick={onCancel}>
             キャンセル

--- a/src/features/routes/reflection-list/sidebar/Sidebar.tsx
+++ b/src/features/routes/reflection-list/sidebar/Sidebar.tsx
@@ -98,6 +98,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 count={folder.countByFolder}
                 username={username}
                 onSelectMode={() => onSelectMode(folder.folderUUID)}
+                onCloseSidebar={() => setSidebarOpen(false)}
                 onSelect={() => handleFolderSelect(folder.folderUUID)}
                 isSelected={selectedFolderUUID === folder.folderUUID}
                 onRefetch={refreshFolders}

--- a/src/features/routes/reflection-list/sidebar/Sidebar.tsx
+++ b/src/features/routes/reflection-list/sidebar/Sidebar.tsx
@@ -98,7 +98,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 count={folder.countByFolder}
                 username={username}
                 onSelectMode={() => onSelectMode(folder.folderUUID)}
-                onCloseSidebar={() => setSidebarOpen(false)}
+                onCloseSidebar={() => setSidebarOpen(false)} // TODO: バケツリレーしすぎなのでzustandに移行してもいいかも
                 onSelect={() => handleFolderSelect(folder.folderUUID)}
                 isSelected={selectedFolderUUID === folder.folderUUID}
                 onRefetch={refreshFolders}

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -20,6 +20,7 @@ type FolderItemProps = {
   folderUUID: string;
   username: string;
   onSelectMode: () => void;
+  onCloseSidebar: () => void;
   isSelected: boolean;
   onSelect: (folderUUID: string) => void;
   count: number;
@@ -33,6 +34,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   folderUUID,
   username,
   onSelectMode,
+  onCloseSidebar,
   isSelected,
   onSelect,
   count,
@@ -146,7 +148,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
       }}
     >
       {isEditFieldOpen ? (
-        <Box display={"flex"} alignItems={"center"}>
+        <Box display="flex" alignItems="center">
           {Content}
         </Box>
       ) : (
@@ -175,6 +177,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
       >
         <FolderKebabButtonPopupContainer
           onSelectMode={onSelectMode}
+          onCloseSidebar={onCloseSidebar}
           onPopupChange={(open) => setIsPopupOpen(open)}
           folderUUID={folderUUID}
           username={username}

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -7,7 +7,8 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  TextField
+  TextField,
+  useMediaQuery
 } from "@mui/material";
 import type { Folder } from "@/src/api/folder-api";
 import { FolderKebabButtonPopupContainer } from "../kebab-button/FolderKebabMenuButtonContainer";
@@ -45,6 +46,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currentFolder = searchParams.get("folder");
+  const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
 
   const href =
     currentFolder === folderUUID
@@ -165,7 +167,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
       )}
       <Box
         className="hover-icons"
-        display={isPopupOpen ? "flex" : "none"}
+        display={isMobile ? "flex" : isPopupOpen ? "flex" : "none"}
         alignItems={"center"}
         gap={1}
         position={"absolute"}

--- a/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
+++ b/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
@@ -10,6 +10,7 @@ type FolderKebabMenuButtonProps = {
   onOpenPopup: (event: React.MouseEvent<HTMLElement>) => void;
   onClosePopup: () => void;
   onSelectMode: () => void;
+  onCloseSidebar: () => void;
   onEditFolderName: () => void;
   onDeleteFolder: () => void;
 };
@@ -20,6 +21,7 @@ export const FolderKebabMenuButton: React.FC<FolderKebabMenuButtonProps> = ({
   onOpenPopup,
   onClosePopup,
   onSelectMode,
+  onCloseSidebar,
   onEditFolderName,
   onDeleteFolder
 }) => {
@@ -77,6 +79,7 @@ export const FolderKebabMenuButton: React.FC<FolderKebabMenuButtonProps> = ({
                 onClick={() => {
                   onClosePopup();
                   onSelectMode();
+                  onCloseSidebar();
                 }}
               />
               <PopupButton

--- a/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButtonContainer.tsx
+++ b/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButtonContainer.tsx
@@ -9,6 +9,7 @@ type FolderKebabButtonPopupContainerProps = {
   username: string;
   setIsEditFieldOpen: (isEditFieldOpen: boolean) => void;
   onSelectMode: () => void;
+  onCloseSidebar: () => void;
   onPopupChange?: (isOpen: boolean) => void;
   onRefetch: (username: string) => Promise<void>;
   setSelectedFolderUUID: (folderUUID: string) => void;
@@ -21,6 +22,7 @@ export const FolderKebabButtonPopupContainer: React.FC<
   username,
   setIsEditFieldOpen,
   onSelectMode,
+  onCloseSidebar,
   onPopupChange,
   onRefetch,
   setSelectedFolderUUID
@@ -76,6 +78,7 @@ export const FolderKebabButtonPopupContainer: React.FC<
         onOpenPopup={handleOpenPopup}
         onClosePopup={handleClosePopup}
         onSelectMode={onSelectMode}
+        onCloseSidebar={onCloseSidebar}
         onEditFolderName={handleEditFolderName}
         onDeleteFolder={handleDeleteFolder}
       />


### PR DESCRIPTION
## 変更点
- 一括選択ボタンを押したらサイドバーが閉じること(こうしないと選択モード時に別のフォルダとかクリックされてカードのUI変わったりするちょっとしたバグがあったので少しマシになった仕様。あとスマホはこの方が体験いい)
- スマホで常時ケバブボタンを表示する

## 動作確認

https://github.com/user-attachments/assets/8319526d-0bc4-43db-9739-c455fc3035dd

## 確認したこと
- ケバブ周りでデグレが起きていないこと

## リリース時確認すること
- PWAで正常に動くか