### PR TITLE
folderUUIDをクエリパラメータとしてセットした  feature/folder UUID param

### DIFF
--- a/src/app/(multi-footer)/[username]/book/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/book/page.client.tsx
@@ -13,6 +13,7 @@ import "@/src/features/routes/reflections-book/my-swiper.css";
 import { useParseTagsToValue } from "@/src/hooks/reflection-tag/useParseTagsToValue";
 import { useSwipeIconVisibility } from "@/src/hooks/reflections-book/useSwipeIconVisibility";
 import { theme } from "@/src/utils/theme";
+import { useSearchParams } from "next/navigation";
 
 type ReflectionsBookPageProps = {
   reflections: ReflectionBook[];
@@ -28,6 +29,8 @@ const ReflectionsBookPage: React.FC<ReflectionsBookPageProps> = ({
   const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const isVisible = useSwipeIconVisibility();
   const { parseTagsToValue } = useParseTagsToValue();
+  const searchParams = useSearchParams();
+  const folderUUID = searchParams.get("folder");
 
   return reflections.length === 0 ? (
     <Box
@@ -43,52 +46,58 @@ const ReflectionsBookPage: React.FC<ReflectionsBookPageProps> = ({
       position={"relative"}
       sx={{ overflowX: { xs: "hidden", md: "visible" } }}
     >
-      {isVisible && <SwipeIconDisplay isVisible={isVisible} />}
-      <Swiper
-        effect="cards"
-        grabCursor={true}
-        modules={[EffectCards, Navigation]}
-        cardsEffect={{
-          slideShadows: false,
-          perSlideRotate: isSmallScreen ? 0 : 2,
-          perSlideOffset: isSmallScreen ? 0 : 8
-        }}
-        navigation
-      >
-        {reflections.map((reflection) => {
-          const activeTags = [
-            reflection.isDailyReflection &&
-              parseTagsToValue("isDailyReflection"),
-            reflection.isLearning && parseTagsToValue("isLearning"),
-            reflection.isAwareness && parseTagsToValue("isAwareness"),
-            reflection.isInputLog && parseTagsToValue("isInputLog"),
-            reflection.isMonologue && parseTagsToValue("isMonologue")
-          ].filter(Boolean) as string[];
-          return (
-            <SwiperSlide key={reflection.reflectionCUID}>
-              <Box
-                mt={{ xs: -8, md: -4 }}
-                position={"relative"}
-                width={"100%"}
-                sx={{
-                  transform: "scale(0.8)"
-                }}
-              >
-                <ReflectionArticle
-                  username={username}
-                  userImage={userImage}
-                  createdAt={reflection.createdAt}
-                  title={reflection.title}
-                  content={reflection.content}
-                  activeTags={activeTags}
-                  reflectionCUID={reflection.reflectionCUID}
-                  isReflectionBook
-                />
-              </Box>
-            </SwiperSlide>
-          );
-        })}
-      </Swiper>
+      {folderUUID ? (
+        <Box>{folderUUID}</Box>
+      ) : (
+        <>
+          {isVisible && <SwipeIconDisplay isVisible={isVisible} />}
+          <Swiper
+            effect="cards"
+            grabCursor={true}
+            modules={[EffectCards, Navigation]}
+            cardsEffect={{
+              slideShadows: false,
+              perSlideRotate: isSmallScreen ? 0 : 2,
+              perSlideOffset: isSmallScreen ? 0 : 8
+            }}
+            navigation
+          >
+            {reflections.map((reflection) => {
+              const activeTags = [
+                reflection.isDailyReflection &&
+                  parseTagsToValue("isDailyReflection"),
+                reflection.isLearning && parseTagsToValue("isLearning"),
+                reflection.isAwareness && parseTagsToValue("isAwareness"),
+                reflection.isInputLog && parseTagsToValue("isInputLog"),
+                reflection.isMonologue && parseTagsToValue("isMonologue")
+              ].filter(Boolean) as string[];
+              return (
+                <SwiperSlide key={reflection.reflectionCUID}>
+                  <Box
+                    mt={{ xs: -8, md: -4 }}
+                    position={"relative"}
+                    width={"100%"}
+                    sx={{
+                      transform: "scale(0.8)"
+                    }}
+                  >
+                    <ReflectionArticle
+                      username={username}
+                      userImage={userImage}
+                      createdAt={reflection.createdAt}
+                      title={reflection.title}
+                      content={reflection.content}
+                      activeTags={activeTags}
+                      reflectionCUID={reflection.reflectionCUID}
+                      isReflectionBook
+                    />
+                  </Box>
+                </SwiperSlide>
+              );
+            })}
+          </Swiper>
+        </>
+      )}
     </Box>
   );
 };

--- a/src/app/(multi-footer)/[username]/book/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/book/page.client.tsx
@@ -19,18 +19,18 @@ type ReflectionsBookPageProps = {
   reflections: ReflectionBook[];
   username: string;
   userImage: string;
+  folderUUID: string | undefined;
 };
 
 const ReflectionsBookPage: React.FC<ReflectionsBookPageProps> = ({
   reflections,
   username,
-  userImage
+  userImage,
+  folderUUID
 }) => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const isVisible = useSwipeIconVisibility();
   const { parseTagsToValue } = useParseTagsToValue();
-  const searchParams = useSearchParams();
-  const folderUUID = searchParams.get("folder");
 
   return reflections.length === 0 ? (
     <Box

--- a/src/app/(multi-footer)/[username]/book/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/book/page.client.tsx
@@ -2,6 +2,7 @@
 import "swiper/css";
 import "swiper/css/effect-cards";
 import "swiper/css/navigation";
+import { useSearchParams } from "next/navigation";
 import { EffectCards, Navigation } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Box, useMediaQuery } from "@mui/material";
@@ -13,7 +14,6 @@ import "@/src/features/routes/reflections-book/my-swiper.css";
 import { useParseTagsToValue } from "@/src/hooks/reflection-tag/useParseTagsToValue";
 import { useSwipeIconVisibility } from "@/src/hooks/reflections-book/useSwipeIconVisibility";
 import { theme } from "@/src/utils/theme";
-import { useSearchParams } from "next/navigation";
 
 type ReflectionsBookPageProps = {
   reflections: ReflectionBook[];

--- a/src/app/(multi-footer)/[username]/book/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/book/page.client.tsx
@@ -2,7 +2,6 @@
 import "swiper/css";
 import "swiper/css/effect-cards";
 import "swiper/css/navigation";
-import { useSearchParams } from "next/navigation";
 import { EffectCards, Navigation } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Box, useMediaQuery } from "@mui/material";

--- a/src/app/(multi-footer)/[username]/book/page.tsx
+++ b/src/app/(multi-footer)/[username]/book/page.tsx
@@ -22,8 +22,17 @@ export const generateMetadata = async ({
   return meta.reflectionsBookPage(params.username);
 };
 
-const page = async ({ params }: { params: { username: string } }) => {
+const page = async ({
+  params,
+  searchParams
+}: {
+  params: { username: string };
+  searchParams: {
+    folder?: string;
+  };
+}) => {
   const session = await getServerSession(authOptions);
+  const folderUUID = searchParams.folder || undefined;
 
   const res = await reflectionsBookAPI.getReflections(params.username);
   if (res === 404 || !res || params.username !== session?.user.username) {
@@ -35,6 +44,7 @@ const page = async ({ params }: { params: { username: string } }) => {
       reflections={res.reflections}
       username={session?.user.username ?? ""}
       userImage={session?.user.image ?? ""}
+      folderUUID={folderUUID}
     />
   );
 };

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -81,7 +81,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ) => {
     e.preventDefault(); // MEMO:<Link> のデフォルトの遷移を防ぐ
-    router.push(`/book/?folder=${folderUUID}`);
+    router.push(`${username}/book/?folder=${folderUUID}`);
   };
 
   const Content = (

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import FolderIcon from "@mui/icons-material/Folder";
 import {
   Box,
@@ -56,7 +56,6 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currentFolder = searchParams.get("folder");
-  const router = useRouter();
 
   const href =
     currentFolder === folderUUID

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { useState } from "react";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import FolderIcon from "@mui/icons-material/Folder";
 import {
   Box,
@@ -56,6 +56,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currentFolder = searchParams.get("folder");
+  const router = useRouter();
 
   const href =
     currentFolder === folderUUID
@@ -73,6 +74,14 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     }
     setIsEditFieldOpen(false);
     onFolderUpdate(updatedFolder);
+  };
+
+  //TODO:page.clientに記載する
+  const handleClickBookIcon = (
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+  ) => {
+    e.preventDefault(); // MEMO:<Link> のデフォルトの遷移を防ぐ
+    router.push(`/book/?folder=${folderUUID}`);
   };
 
   const Content = (
@@ -185,6 +194,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
         <Link
           href={`${username}/book`}
           style={link}
+          onClick={handleClickBookIcon}
           onMouseEnter={(e) =>
             (e.currentTarget.style.backgroundColor = `${theme.palette.grey[100]}`)
           }

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -28,16 +28,6 @@ type FolderItemProps = {
   setSelectedFolderUUID: (folderUUID: string) => void;
 };
 
-const link = {
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  width: "30px",
-  height: "30px",
-  borderRadius: "50%",
-  transition: "background-color 0.3s ease"
-};
-
 export const FolderItem: React.FC<FolderItemProps> = ({
   initialFoldername,
   folderUUID,
@@ -211,4 +201,14 @@ export const FolderItem: React.FC<FolderItemProps> = ({
       </Box>
     </ListItem>
   );
+};
+
+const link = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "30px",
+  height: "30px",
+  borderRadius: "50%",
+  transition: "background-color 0.3s ease"
 };

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -25,6 +26,16 @@ type FolderItemProps = {
   onFolderUpdate: (updatedFolder: Folder) => void;
   onRefetch: () => Promise<void>;
   setSelectedFolderUUID: (folderUUID: string) => void;
+};
+
+const link = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "30px",
+  height: "30px",
+  borderRadius: "50%",
+  transition: "background-color 0.3s ease"
 };
 
 export const FolderItem: React.FC<FolderItemProps> = ({
@@ -171,6 +182,23 @@ export const FolderItem: React.FC<FolderItemProps> = ({
         position={"absolute"}
         right={4}
       >
+        <Link
+          href={`${username}/book`}
+          style={link}
+          onMouseEnter={(e) =>
+            (e.currentTarget.style.backgroundColor = `${theme.palette.grey[100]}`)
+          }
+          onMouseLeave={(e) =>
+            (e.currentTarget.style.backgroundColor = "transparent")
+          }
+        >
+          <Image
+            src={"/book.svg"}
+            alt={"マイブックへ行くアイコンボタン"}
+            width={20}
+            height={20}
+          />
+        </Link>
         <FolderKebabButtonPopupContainer
           onSelectMode={onSelectMode}
           onPopupChange={(open) => setIsPopupOpen(open)}

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -76,14 +76,6 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     onFolderUpdate(updatedFolder);
   };
 
-  //TODO:page.clientに記載する
-  const handleClickBookIcon = (
-    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
-  ) => {
-    e.preventDefault(); // MEMO:<Link> のデフォルトの遷移を防ぐ
-    router.push(`${username}/book/?folder=${folderUUID}`);
-  };
-
   const Content = (
     <>
       <ListItemIcon sx={{ minWidth: "27px" }}>
@@ -192,9 +184,8 @@ export const FolderItem: React.FC<FolderItemProps> = ({
         right={4}
       >
         <Link
-          href={`${username}/book`}
+          href={`${username}/book/?folder=${folderUUID}`}
           style={link}
-          onClick={handleClickBookIcon}
           onMouseEnter={(e) =>
             (e.currentTarget.style.backgroundColor = `${theme.palette.grey[100]}`)
           }

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -1,5 +1,5 @@
-import Image from "next/image";
 import { useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import FolderIcon from "@mui/icons-material/Folder";


### PR DESCRIPTION
@yusei53 
folderUUIDをクエリパラメータとしてセットし、bookページで取得できるようにしました！
お手隙の際にご確認お願いします！
## やったこと
- bookページに飛べるアイコンをSidebarのFolderItemに設置
- クエリパラメータをfolderUUIDとし、FolderItemコンポーネントでセットした
 （`router.push(${username}/book/?folder=${folderUUID});`）
- セットしたクエリパラメータをbookのpage.clientで取得した
- 確認のため、folderUUIDがある場合はfolderUUIDを表示させ、ない場合は通常のmybook機能を表示させるようにした

## 挙動
フォルダの場所のアイコンをクリックする→folderUUIDが表示される
プロフィールの本のアイコンをクリックする→今まで通りのマイブック機能が表示される

https://github.com/user-attachments/assets/cd470a2f-b20a-496a-8ad8-4184dfda2aec



## 別ブランチでやること
- apiの作成
- UIの調整
- リファクタ