### PR TITLE
一括追加から一括編集の機能実装にする

### DIFF
--- a/src/api/reflection-api.ts
+++ b/src/api/reflection-api.ts
@@ -22,7 +22,6 @@ export type Reflection = {
   isAwareness: boolean;
   isInputLog: boolean;
   isMonologue: boolean;
-  folderUUID: string | null;
   createdAt: string;
 };
 

--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -122,6 +122,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
     setSelectedReflections([]);
     setIsLoading(false);
     router.push(`/${username}?folder=${selectedFolderUUID}`);
+    router.refresh();
   };
   const isFolderSelected = foldersState.some(
     (f) => f.folderUUID === selectedFolderUUID

--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -77,11 +77,14 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   const setSelectedFolderUUID = useFolderStore(
     (state) => state.setSelectedFolderUUID
   );
-
   const handleSelectMode = (folderUUID: string) => {
     router.push(pathname);
     setIsSelectMode(true);
     setSelectedFolderUUID(folderUUID);
+    const preSelected = reflections
+      .filter((r) => r.folderUUID === folderUUID)
+      .map((r) => r.reflectionCUID);
+    setSelectedReflections(preSelected);
   };
 
   const handleSelect = (reflectionCUID: string) => {

--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -26,6 +26,7 @@ import { Sidebar } from "@/src/features/routes/reflection-list/sidebar";
 import { FolderInitializer } from "@/src/features/routes/reflection-list/sidebar/FolderInitializer";
 import { usePagination } from "@/src/hooks/reflection/usePagination";
 import { tagMap } from "@/src/hooks/reflection-tag/useExtractTrueTags";
+import { getReflectionWithFolderInfo } from "@/src/utils/actions/get-reflection-with-folder-info";
 import { useFolderStore } from "@/src/utils/store/useFolderStore";
 import { theme } from "@/src/utils/theme";
 
@@ -77,13 +78,13 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   const setSelectedFolderUUID = useFolderStore(
     (state) => state.setSelectedFolderUUID
   );
-  const handleSelectMode = (folderUUID: string) => {
+  const handleSelectMode = async (folderUUID: string) => {
     router.push(pathname);
     setIsSelectMode(true);
     setSelectedFolderUUID(folderUUID);
-    const preSelected = reflections
-      .filter((r) => r.folderUUID === folderUUID)
-      .map((r) => r.reflectionCUID);
+    const info = await getReflectionWithFolderInfo(username, folderUUID);
+    if (!info) return;
+    const preSelected = info.map((i) => i.reflectionCUID);
     setSelectedReflections(preSelected);
   };
 

--- a/src/app/api/reflection/bulk-select/route.ts
+++ b/src/app/api/reflection/bulk-select/route.ts
@@ -13,7 +13,11 @@ import {
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const { reflectionCUID, folderUUID, username } = body;
+    const {
+      reflectionCUID: selectedReflectionList,
+      folderUUID,
+      username
+    } = body;
     const userId = await getUserIdByUsername(username);
 
     const session = await getServerSession(authOptions);
@@ -21,7 +25,7 @@ export async function POST(req: Request) {
       return unauthorizedError("認証されていません");
     }
 
-    if (!Array.isArray(reflectionCUID) || !folderUUID || !userId) {
+    if (!Array.isArray(selectedReflectionList) || !folderUUID || !userId) {
       return badRequestError(
         "投稿一括選択のリクエストパラメータに不整合があります"
       );
@@ -31,13 +35,13 @@ export async function POST(req: Request) {
     const selected = await prisma.reflection.findMany({
       where: {
         reflectionCUID: {
-          in: reflectionCUID
+          in: selectedReflectionList
         },
         userId
       }
     });
 
-    if (selected.length !== reflectionCUID.length) {
+    if (selected.length !== selectedReflectionList.length) {
       return forbiddenError("選択した投稿の中に自分の投稿以外が含まれています");
     }
 
@@ -46,16 +50,19 @@ export async function POST(req: Request) {
         where: {
           userId,
           folderUUID,
-          // MEMO: 現在フォルダに入っているが、今回選択されていない投稿をフォルダから外す
-          reflectionCUID: { notIn: reflectionCUID }
+          // MEMO: 現在あるフォルダに所属している投稿のうち、
+          //       今回選択されなかった投稿（selectedReflectionListに含まれていないもの）
+          //       のフォルダ設定を解除する（folderUUIDをnullにする）。
+          reflectionCUID: { notIn: selectedReflectionList }
         },
         data: { folderUUID: null }
       }),
       prisma.reflection.updateMany({
         where: {
           userId,
-          // MEMO: 選択された投稿をフォルダに入れる
-          reflectionCUID: { in: reflectionCUID }
+          // MEMO: 今回選択された投稿（selectedReflectionListに含まれるもの）
+          //       に対して、指定されたフォルダに設定する（folderUUIDを更新する）。
+          reflectionCUID: { in: selectedReflectionList }
         },
         data: { folderUUID }
       })

--- a/src/features/routes/reflection-list/selection-header/SelectionHeader.tsx
+++ b/src/features/routes/reflection-list/selection-header/SelectionHeader.tsx
@@ -53,7 +53,7 @@ export const SelectionHeader: React.FC<SelectionHeaderProps> = ({
             onClick={onAdd}
             disabled={disableAdd}
           >
-            追加
+            更新
           </Button>
         </Box>
       )}

--- a/src/features/routes/reflection-list/sidebar/Sidebar.tsx
+++ b/src/features/routes/reflection-list/sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ import { theme } from "@/src/utils/theme";
 type SidebarProps = {
   username: string;
   tagCountList: ReflectionTagCountList;
-  onSelectMode: (folderUUID: string) => void;
+  onSelectMode: (folderUUID: string) => Promise<void>;
 };
 
 export const Sidebar: React.FC<SidebarProps> = ({

--- a/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
+++ b/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
@@ -71,7 +71,7 @@ export const FolderKebabMenuButton: React.FC<FolderKebabMenuButtonProps> = ({
               minWidth={200}
             >
               <PopupButton
-                text={"投稿をフォルダに追加"}
+                text={"フォルダ内を編集"}
                 src={"/add-to-folder.svg"}
                 alt={`フォルダに投稿を追加するボタン`}
                 onClick={() => {

--- a/src/infrastructure/repository/reflectionRepository.ts
+++ b/src/infrastructure/repository/reflectionRepository.ts
@@ -86,8 +86,7 @@ export const reflectionRepository = {
             charStamp: true,
             createdAt: true,
             isPublic: true,
-            isPinned: true,
-            folderUUID: true
+            isPinned: true
           }
         }
       }

--- a/src/infrastructure/repository/reflectionRepository.ts
+++ b/src/infrastructure/repository/reflectionRepository.ts
@@ -86,7 +86,8 @@ export const reflectionRepository = {
             charStamp: true,
             createdAt: true,
             isPublic: true,
-            isPinned: true
+            isPinned: true,
+            folderUUID: true
           }
         }
       }

--- a/src/utils/actions/get-reflection-with-folder-info.ts
+++ b/src/utils/actions/get-reflection-with-folder-info.ts
@@ -1,0 +1,33 @@
+"use server";
+import { getUserIdByUsername } from "./get-userId-by-username";
+import prisma from "@/src/lib/prisma";
+
+type FolderInfo = {
+  reflectionCUID: string;
+  folderUUID: string | null;
+};
+
+// MEMO: エッジケースなデータ取得は一旦serverActionで対応
+export const getReflectionWithFolderInfo = async (
+  username: string,
+  folderUUID: string
+): Promise<FolderInfo[] | null> => {
+  try {
+    const userId = await getUserIdByUsername(username);
+    if (!userId) return null;
+    const info = await prisma.reflection.findMany({
+      where: {
+        userId,
+        folderUUID
+      },
+      select: {
+        reflectionCUID: true,
+        folderUUID: true
+      }
+    });
+    return info;
+  } catch (error) {
+    console.error("Error fetching folder info:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
## やったこと
- 一括追加のみしかできず、フォルダから削除ができなかったのでそれをできるようにする
- 選択モードにした時すでにフォルダに入っているものはチェックがつくようにした
- ボタンを追加→更新にした


## 動作確認
https://github.com/user-attachments/assets/7361e5ca-6678-44cd-9ede-3c2d75ff63b6

