### PR TITLE
選択しているフォルダを再選択した時、文言を消す

### DIFF
--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -130,19 +130,22 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
     router.push(`/${username}`);
   };
 
-  let selected: { name: string; count: number } | null = null;
-  const folder = foldersState.find((f) => f.folderUUID === selectedInfo);
-  if (folder) {
-    selected = {
-      name: folder.name,
-      count: folder.countByFolder || 0
-    };
-  } else if (tagMap[selectedInfo as keyof TagType]) {
-    selected = {
-      name: tagMap[selectedInfo as keyof TagType],
-      count: tagCountList[selectedInfo as keyof ReflectionTagCountList] || 0
-    };
-  }
+  const currentFolder = foldersState.find((f) => f.folderUUID === selectedInfo);
+  const selected = (() => {
+    if (currentFolder) {
+      return {
+        name: currentFolder.name,
+        count: currentFolder.countByFolder || 0
+      };
+    }
+    if (tagMap[selectedInfo as keyof TagType]) {
+      return {
+        name: tagMap[selectedInfo as keyof TagType],
+        count: tagCountList[selectedInfo as keyof ReflectionTagCountList] || 0
+      };
+    }
+    return null;
+  })();
 
   return (
     <>

--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -70,17 +70,13 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   const { handlePageChange } = usePagination();
 
   const foldersState = useFolderStore((state) => state.folders);
-  const selectedFolderUUID = useFolderStore(
-    (state) => state.selectedFolderUUID
-  );
+  const selectedInfo = useFolderStore((state) => state.selectedInfo);
   const setFolders = useFolderStore((state) => state.setFolders);
-  const setSelectedFolderUUID = useFolderStore(
-    (state) => state.setSelectedFolderUUID
-  );
+  const setSelectedInfo = useFolderStore((state) => state.setSelectedInfo);
   const handleSelectMode = async (folderUUID: string) => {
     router.push(pathname);
     setIsSelectMode(true);
-    setSelectedFolderUUID(folderUUID);
+    setSelectedInfo(folderUUID);
     const info = await getReflectionWithFolderInfo(username, folderUUID);
     if (!info) return;
     const preSelected = info.map((i) => i.reflectionCUID);
@@ -100,7 +96,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   const handleCancelSelectMode = () => {
     setIsSelectMode(false);
     setSelectedReflections([]);
-    setSelectedFolderUUID("");
+    setSelectedInfo("");
   };
 
   const handleAddReflectionToFolder = async () => {
@@ -108,7 +104,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
 
     await reflectionAPI.bulkUpdateFolderReflection({
       reflectionCUID: selectedReflections,
-      folderUUID: selectedFolderUUID,
+      folderUUID: selectedInfo,
       username
     });
     const updatedFolders = await folderAPI.getFolder(username);
@@ -120,11 +116,11 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
     setIsSelectMode(false);
     setSelectedReflections([]);
     setIsLoading(false);
-    router.push(`/${username}?folder=${selectedFolderUUID}`);
+    router.push(`/${username}?folder=${selectedInfo}`);
     router.refresh();
   };
   const isFolderSelected = foldersState.some(
-    (f) => f.folderUUID === selectedFolderUUID
+    (f) => f.folderUUID === selectedInfo
   );
   const disableAdd = selectedReflections.length === 0 || isLoading;
 
@@ -134,23 +130,18 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
     router.push(`/${username}`);
   };
 
-  let selectedInfo: { name: string; count: number } | null = null;
-  if (selectedFolderUUID !== "") {
-    const folder = foldersState.find(
-      (f) => f.folderUUID === selectedFolderUUID
-    );
-    if (folder) {
-      selectedInfo = {
-        name: folder.name,
-        count: folder.countByFolder || 0
-      };
-    } else if (tagMap[selectedFolderUUID as keyof TagType]) {
-      selectedInfo = {
-        name: tagMap[selectedFolderUUID as keyof TagType],
-        count:
-          tagCountList[selectedFolderUUID as keyof ReflectionTagCountList] || 0
-      };
-    }
+  let selected: { name: string; count: number } | null = null;
+  const folder = foldersState.find((f) => f.folderUUID === selectedInfo);
+  if (folder) {
+    selected = {
+      name: folder.name,
+      count: folder.countByFolder || 0
+    };
+  } else if (tagMap[selectedInfo as keyof TagType]) {
+    selected = {
+      name: tagMap[selectedInfo as keyof TagType],
+      count: tagCountList[selectedInfo as keyof ReflectionTagCountList] || 0
+    };
   }
 
   return (
@@ -175,7 +166,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
           isCurrentUser={isCurrentUser}
         />
         <SelectionHeader
-          selectedInfo={selectedInfo}
+          selectedInfo={selected}
           isFolderSelected={isFolderSelected}
           isSelectMode={isSelectMode}
           onCancel={handleCancelSelectMode}

--- a/src/features/routes/reflection-list/sidebar/Sidebar.tsx
+++ b/src/features/routes/reflection-list/sidebar/Sidebar.tsx
@@ -26,29 +26,25 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
 
   const folders = useFolderStore((state) => state.folders);
-  const selectedFolderUUID = useFolderStore(
-    (state) => state.selectedFolderUUID
-  );
-  const setSelectedFolderUUID = useFolderStore(
-    (state) => state.setSelectedFolderUUID
-  );
+  const selectedInfo = useFolderStore((state) => state.selectedInfo);
+  const setSelectedInfo = useFolderStore((state) => state.setSelectedInfo);
   const refreshFolders = useFolderStore((state) => state.refreshFolders);
   const updatedFolders = useFolderStore((state) => state.updateFolder);
 
   const handleFolderSelect = (folderUUID: string) => {
-    if (selectedFolderUUID === folderUUID) {
-      setSelectedFolderUUID("");
+    if (selectedInfo === folderUUID) {
+      setSelectedInfo("");
     } else {
-    setSelectedFolderUUID(folderUUID);
+      setSelectedInfo(folderUUID);
     }
     if (isMobile) setSidebarOpen(false);
   };
 
   const handleTagSelect = (tagKey: string) => {
-    if (selectedFolderUUID === tagKey) {
-      setSelectedFolderUUID("");
+    if (selectedInfo === tagKey) {
+      setSelectedInfo("");
     } else {
-    setSelectedFolderUUID(tagKey);
+      setSelectedInfo(tagKey);
     }
     if (isMobile) setSidebarOpen(false);
   };
@@ -109,10 +105,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 onSelectMode={() => onSelectMode(folder.folderUUID)}
                 onCloseSidebar={() => setSidebarOpen(false)} // TODO: バケツリレーしすぎなのでzustandに移行してもいいかも
                 onSelect={() => handleFolderSelect(folder.folderUUID)}
-                isSelected={selectedFolderUUID === folder.folderUUID}
+                isSelected={selectedInfo === folder.folderUUID}
                 onRefetch={refreshFolders}
                 onFolderUpdate={updatedFolders}
-                setSelectedFolderUUID={setSelectedFolderUUID}
+                setSelectedFolderUUID={setSelectedInfo}
               />
             ))}
             <CreateFolderField username={username} onRefetch={refreshFolders} />
@@ -123,7 +119,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 tagKey={key as keyof TagType}
                 tagname={label}
                 key={key}
-                isSelected={selectedFolderUUID === key}
+                isSelected={selectedInfo === key}
                 onSelect={() => handleTagSelect(key)}
                 count={tagCountList[key as keyof ReflectionTagCountList] || 0}
               />

--- a/src/features/routes/reflection-list/sidebar/Sidebar.tsx
+++ b/src/features/routes/reflection-list/sidebar/Sidebar.tsx
@@ -36,11 +36,20 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const updatedFolders = useFolderStore((state) => state.updateFolder);
 
   const handleFolderSelect = (folderUUID: string) => {
+    if (selectedFolderUUID === folderUUID) {
+      setSelectedFolderUUID("");
+    } else {
     setSelectedFolderUUID(folderUUID);
+    }
     if (isMobile) setSidebarOpen(false);
   };
+
   const handleTagSelect = (tagKey: string) => {
+    if (selectedFolderUUID === tagKey) {
+      setSelectedFolderUUID("");
+    } else {
     setSelectedFolderUUID(tagKey);
+    }
     if (isMobile) setSidebarOpen(false);
   };
 

--- a/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
+++ b/src/features/routes/reflection-list/sidebar/kebab-button/FolderKebabMenuButton.tsx
@@ -70,7 +70,7 @@ export const FolderKebabMenuButton: React.FC<FolderKebabMenuButtonProps> = ({
               boxShadow={1}
               borderRadius={2.5}
               bgcolor={"white"}
-              minWidth={200}
+              minWidth={180}
             >
               <PopupButton
                 text={"フォルダ内を編集"}

--- a/src/utils/store/useFolderStore.ts
+++ b/src/utils/store/useFolderStore.ts
@@ -4,18 +4,18 @@ import { folderAPI } from "@/src/api/folder-api";
 
 type FolderStore = {
   folders: Folder[];
-  selectedFolderUUID: string;
+  selectedInfo: string;
   setFolders: (folders: Folder[]) => void;
-  setSelectedFolderUUID: (uuid: string) => void;
+  setSelectedInfo: (uuid: string) => void;
   refreshFolders: (username: string) => Promise<void>;
   updateFolder: (updatedFolder: Folder) => void;
 };
 
 export const useFolderStore = create<FolderStore>((set) => ({
   folders: [],
-  selectedFolderUUID: "",
+  selectedInfo: "",
   setFolders: (folders: Folder[]) => set({ folders }),
-  setSelectedFolderUUID: (uuid: string) => set({ selectedFolderUUID: uuid }),
+  setSelectedInfo: (uuid: string) => set({ selectedInfo: uuid }),
   refreshFolders: async (username: string) => {
     const updatedFolders = await folderAPI.getFolder(username);
     if (Array.isArray(updatedFolders)) {


### PR DESCRIPTION
## やったこと
- 選択しているフォルダを再選択した時、文言を消す
- useFolderStoreの中の変数を変えた
  - 元々使っていた`selectedFolderUUID`に、タグの情報が入ってくる場合があったため
- ケバブボタンのwidth縮小

## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/378d05c0-bf63-4394-8b9c-f4246a33628e

## 確認したこと(デグレチェック)
- 正常に追加、削除、フォルダ内更新ができること

## リリース時本番環境で確認すること
