### PR TITLE
フォルダのCSSの調整

### DIFF
--- a/src/features/common/post-form/ReflectionPostForm.tsx
+++ b/src/features/common/post-form/ReflectionPostForm.tsx
@@ -154,7 +154,6 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
             py={0.8}
             boxShadow={"0px 0.7px 1px rgba(0, 0, 0, 0.1)"}
             display={"flex"}
-            flexDirection={"row"}
             gap={2}
             whiteSpace={"nowrap"}
             sx={{
@@ -208,7 +207,7 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
             )}
           />
           {!isSmallScreen && (
-            <Box display={"flex"} flexDirection={"row"} gap={2}>
+            <Box display={"flex"} gap={2}>
               <SelectTagPopupContainer
                 value={activeTags}
                 onTagChange={onTagChange}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -39,11 +39,11 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
         <Button
           onClick={onPopupOpen}
           sx={{
+            mx: 0.5,
             bgcolor: theme.palette.primary.main,
             border: "#ededed solid 1px",
             borderRadius: 2,
             height: "30px",
-            cursor: "pointer",
             p: 1
           }}
         >

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -54,7 +54,14 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
               mr: 0.5
             }}
           />
-          フォルダ
+          <Typography
+            sx={{
+              fontSize: "14px",
+              lineHeight: "1"
+            }}
+          >
+            フォルダ
+          </Typography>
         </Button>
         {selectedFolderUUID ? (
           <Box display={"flex"} mx={0.4} zIndex={3}>

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -57,7 +57,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
           フォルダ
         </Button>
         {selectedFolderUUID ? (
-          <Box display={"flex"} mx={0.4} zIndex={3}>
+          <Box display={"flex"} mx={0.8} zIndex={3}>
             <Box
               display={"flex"}
               alignItems={"center"}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -35,7 +35,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
 }) => {
   return (
     <>
-      <Box display="flex" alignItems="center">
+      <Box display={"flex"} alignItems={"center"}>
         <Button
           onClick={onPopupOpen}
           sx={{
@@ -44,6 +44,8 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
             border: "#ededed solid 1px",
             borderRadius: 2,
             height: "30px",
+            display: "flex",
+            alignItems: "center",
             p: 1
           }}
         >
@@ -54,14 +56,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
               mr: 0.5
             }}
           />
-          <Typography
-            sx={{
-              fontSize: "14px",
-              lineHeight: "1"
-            }}
-          >
-            フォルダ
-          </Typography>
+          フォルダ
         </Button>
         {selectedFolderUUID ? (
           <Box display={"flex"} mx={0.4} zIndex={3}>

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -39,6 +39,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
         <Button
           onClick={onPopupOpen}
           sx={{
+            mr: 0.5,
             bgcolor: theme.palette.primary.main,
             border: "#ededed solid 1px",
             borderRadius: 2,
@@ -57,7 +58,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
           フォルダ
         </Button>
         {selectedFolderUUID ? (
-          <Box display={"flex"} mx={0.8} zIndex={3}>
+          <Box display={"flex"} mx={0.4} zIndex={3}>
             <Box
               display={"flex"}
               alignItems={"center"}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -39,7 +39,6 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
         <Button
           onClick={onPopupOpen}
           sx={{
-            mr: 0.5,
             bgcolor: theme.palette.primary.main,
             border: "#ededed solid 1px",
             borderRadius: 2,

--- a/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
+++ b/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
@@ -43,8 +43,16 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
           }}
         >
           <TagIcon sx={{ color: theme.palette.grey[500], fontSize: 18 }} />
-          タグ
+          <Typography
+            sx={{
+              fontSize: "14px",
+              lineHeight: "1"
+            }}
+          >
+            タグ
+          </Typography>
         </Button>
+
         {activeTags.map((tag) => (
           <Box key={tag} display={"flex"} mx={0.4} zIndex={3}>
             <Box

--- a/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
+++ b/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
@@ -39,18 +39,13 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
             border: "#ededed solid 1px",
             borderRadius: 2,
             height: "30px",
+            display: "flex",
+            alignItems: "center",
             p: 1
           }}
         >
           <TagIcon sx={{ color: theme.palette.grey[500], fontSize: 18 }} />
-          <Typography
-            sx={{
-              fontSize: "14px",
-              lineHeight: "1"
-            }}
-          >
-            タグ
-          </Typography>
+          タグ
         </Button>
 
         {activeTags.map((tag) => (

--- a/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
+++ b/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
@@ -34,11 +34,12 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
         <Button
           onClick={onPopupOpen}
           sx={{
+            mx: 0.5,
             bgcolor: theme.palette.primary.main,
             border: "#ededed solid 1px",
             borderRadius: 2,
             height: "30px",
-            p: 0
+            p: 1
           }}
         >
           <TagIcon sx={{ color: theme.palette.grey[500], fontSize: 18 }} />

--- a/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
+++ b/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
@@ -34,7 +34,6 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
         <Button
           onClick={onPopupOpen}
           sx={{
-            mr: 0.5,
             bgcolor: theme.palette.primary.main,
             border: "#ededed solid 1px",
             borderRadius: 2,


### PR DESCRIPTION
@yusei53 お疲れ様です。お手隙の際にご確認お願いします！
### やったこと
- flexDirection={"row"}をPC・スマホから消した
- タグ間の空白とフォルダ間の空白をそろえた
### 疑問
修正前後で mx の値が異なる理由が分からず困っています。

SelectTagPopup.tsx の 49 行目：<Box key={tag} display={"flex"} mx={0.4} zIndex={3} />
これは選ばれたタグの間隔を調整する箇所いました。

FolderSettingPopupSettingArea.tsx の 60 行目:
ここが選ばれたフォルダとフォルダの間だと思いました。。。
ですが、修正前から同じコードだったのに、レイアウトのズレ が発生していました。

→ mx を 0.8 に変更したら、いい感じの見た目になりました。
見た目の調整だけで対応してしまったため、issueのタグのCSSをコピーするに対応できていない。

<img width="960" alt="Image" src="https://github.com/user-attachments/assets/b4c1a222-2bf0-4c6e-ae8f-7e4693445d0f" />

### 動作確認

![Image](https://github.com/user-attachments/assets/ea3e020d-863d-42d9-b766-2288c1a9af59)

