### PR TITLE
フォルダがないときの修正

### DIFF
--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -24,70 +24,6 @@ export const label = {
   backgroundColor: "white"
 };
 
-type FolderPopupContentProps = {
-  folders: Folder[];
-  selectedFolderUUID: string | null;
-  setSelectedFolderUUID: (value: string | null) => void;
-  onClose: () => void;
-};
-
-const FolderPopupContent: React.FC<FolderPopupContentProps> = ({
-  folders,
-  selectedFolderUUID,
-  setSelectedFolderUUID,
-  onClose
-}) => {
-  const isFoldersEmpty = folders.length === 0;
-  return (
-    <>
-      <Box
-        px={1}
-        py={isFoldersEmpty ? 0.5 : 1}
-        maxWidth="250px"
-        bgcolor="#f8fbff"
-        border={`1px solid ${theme.palette.grey[400]}`}
-        borderRadius={4}
-      >
-        <Typography
-          component={"span"}
-          sx={{ color: theme.palette.grey[500] }}
-          fontSize={12}
-          ml={folders.length < 2 ? 0 : 1}
-        >
-          {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
-        </Typography>
-        <Box
-          display={"flex"}
-          flexDirection={"row"}
-          flexWrap={"wrap"}
-          gap={1}
-          mt={0.5}
-        >
-          {!isFoldersEmpty &&
-            folders.map((folder) => (
-              <Button
-                key={folder.folderUUID}
-                onClick={() => {
-                  setSelectedFolderUUID(folder.folderUUID);
-                  onClose();
-                }}
-                sx={{
-                  ...label,
-                  bgcolor:
-                    selectedFolderUUID === folder.folderUUID
-                      ? theme.palette.primary.main
-                      : "white"
-                }}
-              >
-                <Typography fontSize={12}>{folder.name}</Typography>
-              </Button>
-            ))}
-        </Box>
-      </Box>
-    </>
-  );
-};
-
 export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
   selectedFolderUUID,
   setSelectedFolderUUID,
@@ -97,6 +33,8 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
   onClose,
   onPopupOpen
 }) => {
+  const isFoldersEmpty = folders.length === 0;
+
   return (
     <>
       <Box display="flex" alignItems="center">
@@ -152,13 +90,49 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
       <Popper open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
-            <Box>
-              <FolderPopupContent
-                folders={folders}
-                selectedFolderUUID={selectedFolderUUID}
-                setSelectedFolderUUID={setSelectedFolderUUID}
-                onClose={onClose}
-              />
+            <Box
+              px={1}
+              py={isFoldersEmpty ? 0.5 : 1}
+              maxWidth="250px"
+              bgcolor="#f8fbff"
+              border={`1px solid ${theme.palette.grey[400]}`}
+              borderRadius={4}
+            >
+              <Typography
+                component={"span"}
+                sx={{ color: theme.palette.grey[500] }}
+                fontSize={12}
+                ml={folders.length < 2 ? 0 : 1}
+              >
+                {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
+              </Typography>
+              <Box
+                display={"flex"}
+                flexDirection={"row"}
+                flexWrap={"wrap"}
+                gap={1}
+                mt={0.5}
+              >
+                {!isFoldersEmpty &&
+                  folders.map((folder) => (
+                    <Button
+                      key={folder.folderUUID}
+                      onClick={() => {
+                        setSelectedFolderUUID(folder.folderUUID);
+                        onClose();
+                      }}
+                      sx={{
+                        ...label,
+                        bgcolor:
+                          selectedFolderUUID === folder.folderUUID
+                            ? theme.palette.primary.main
+                            : "white"
+                      }}
+                    >
+                      <Typography fontSize={12}>{folder.name}</Typography>
+                    </Button>
+                  ))}
+              </Box>
             </Box>
           </Fade>
         )}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -33,6 +33,8 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
   onClose,
   onPopupOpen
 }) => {
+  const isFoldersEmpty = folders.length === 0;
+
   return (
     <>
       <Box display="flex" alignItems="center">
@@ -101,7 +103,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
                 fontSize={12}
                 ml={1}
               >
-                1つ選択できます
+                {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
               </Typography>
               <Box
                 display={"flex"}
@@ -110,25 +112,26 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
                 gap={1}
                 mt={0.5}
               >
-                {folders.map((folder) => (
-                  // TODO: 後でリファクタする
-                  <Button
-                    key={folder.folderUUID}
-                    onClick={() => {
-                      setSelectedFolderUUID(folder.folderUUID);
-                      onClose();
-                    }}
-                    sx={{
-                      ...label,
-                      bgcolor:
-                        selectedFolderUUID === folder.folderUUID
-                          ? theme.palette.primary.main
-                          : "white"
-                    }}
-                  >
-                    <Typography fontSize={12}>{folder.name}</Typography>
-                  </Button>
-                ))}
+                {!isFoldersEmpty &&
+                  folders.map((folder) => (
+                    // TODO: 後でリファクタする
+                    <Button
+                      key={folder.folderUUID}
+                      onClick={() => {
+                        setSelectedFolderUUID(folder.folderUUID);
+                        onClose();
+                      }}
+                      sx={{
+                        ...label,
+                        bgcolor:
+                          selectedFolderUUID === folder.folderUUID
+                            ? theme.palette.primary.main
+                            : "white"
+                      }}
+                    >
+                      <Typography fontSize={12}>{folder.name}</Typography>
+                    </Button>
+                  ))}
               </Box>
             </Box>
           </Fade>

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -28,7 +28,6 @@ type FolderPopupContentProps = {
   folders: Folder[];
   selectedFolderUUID: string | null;
   setSelectedFolderUUID: (value: string | null) => void;
-  isFoldersEmpty: boolean;
   onClose: () => void;
 };
 
@@ -36,45 +35,54 @@ const FolderPopupContent: React.FC<FolderPopupContentProps> = ({
   folders,
   selectedFolderUUID,
   setSelectedFolderUUID,
-  isFoldersEmpty,
   onClose
 }) => {
+  const isFoldersEmpty = folders.length === 0;
   return (
     <>
-      <Typography
-        component={"span"}
-        sx={{ color: theme.palette.grey[500] }}
-        fontSize={12}
-        ml={folders.length < 2 ? 0 : 1}
-      >
-        {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
-      </Typography>
       <Box
-        display={"flex"}
-        flexDirection={"row"}
-        flexWrap={"wrap"}
-        gap={1}
-        mt={0.5}
+        px={1}
+        py={isFoldersEmpty ? 0.5 : 1}
+        maxWidth="250px"
+        bgcolor="#f8fbff"
+        border={`1px solid ${theme.palette.grey[400]}`}
+        borderRadius={4}
       >
-        {!isFoldersEmpty &&
-          folders.map((folder) => (
-            <Button
-              key={folder.folderUUID}
-              onClick={() => {
-                setSelectedFolderUUID(folder.folderUUID);
-                onClose();
-              }}
-              sx={{
-                ...label,
-                bgcolor:
-                  selectedFolderUUID === folder.folderUUID
-                    ? theme.palette.primary.main
-                    : "white"
-              }}
-            >
-              <Typography fontSize={12}>{folder.name}</Typography>
-            </Button>
-          ))}
+        <Typography
+          component={"span"}
+          sx={{ color: theme.palette.grey[500] }}
+          fontSize={12}
+          ml={folders.length < 2 ? 0 : 1}
+        >
+          {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
+        </Typography>
+        <Box
+          display={"flex"}
+          flexDirection={"row"}
+          flexWrap={"wrap"}
+          gap={1}
+          mt={0.5}
+        >
+          {!isFoldersEmpty &&
+            folders.map((folder) => (
+              <Button
+                key={folder.folderUUID}
+                onClick={() => {
+                  setSelectedFolderUUID(folder.folderUUID);
+                  onClose();
+                }}
+                sx={{
+                  ...label,
+                  bgcolor:
+                    selectedFolderUUID === folder.folderUUID
+                      ? theme.palette.primary.main
+                      : "white"
+                }}
+              >
+                <Typography fontSize={12}>{folder.name}</Typography>
+              </Button>
+            ))}
+        </Box>
       </Box>
     </>
   );
@@ -89,8 +97,6 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
   onClose,
   onPopupOpen
 }) => {
-  const isFoldersEmpty = folders.length === 0;
-
   return (
     <>
       <Box display="flex" alignItems="center">
@@ -146,17 +152,9 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
       <Popper open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
-            <Box
-              px={1}
-              py={isFoldersEmpty ? 0.5 : 1}
-              maxWidth="250px"
-              bgcolor="#f8fbff"
-              border={`1px solid ${theme.palette.grey[400]}`}
-              borderRadius={4}
-            >
+            <Box>
               <FolderPopupContent
                 folders={folders}
-                isFoldersEmpty={isFoldersEmpty}
                 selectedFolderUUID={selectedFolderUUID}
                 setSelectedFolderUUID={setSelectedFolderUUID}
                 onClose={onClose}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -24,6 +24,62 @@ export const label = {
   backgroundColor: "white"
 };
 
+type FolderPopupContentProps = {
+  folders: Folder[];
+  selectedFolderUUID: string | null;
+  setSelectedFolderUUID: (value: string | null) => void;
+  isFoldersEmpty: boolean;
+  onClose: () => void;
+};
+
+const FolderPopupContent: React.FC<FolderPopupContentProps> = ({
+  folders,
+  selectedFolderUUID,
+  setSelectedFolderUUID,
+  isFoldersEmpty,
+  onClose
+}) => {
+  return (
+    <>
+      <Typography
+        component={"span"}
+        sx={{ color: theme.palette.grey[500] }}
+        fontSize={12}
+        ml={folders.length < 2 ? 0 : 1}
+      >
+        {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
+      </Typography>
+      <Box
+        display={"flex"}
+        flexDirection={"row"}
+        flexWrap={"wrap"}
+        gap={1}
+        mt={0.5}
+      >
+        {!isFoldersEmpty &&
+          folders.map((folder) => (
+            <Button
+              key={folder.folderUUID}
+              onClick={() => {
+                setSelectedFolderUUID(folder.folderUUID);
+                onClose();
+              }}
+              sx={{
+                ...label,
+                bgcolor:
+                  selectedFolderUUID === folder.folderUUID
+                    ? theme.palette.primary.main
+                    : "white"
+              }}
+            >
+              <Typography fontSize={12}>{folder.name}</Typography>
+            </Button>
+          ))}
+      </Box>
+    </>
+  );
+};
+
 export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
   selectedFolderUUID,
   setSelectedFolderUUID,
@@ -98,42 +154,13 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
               border={`1px solid ${theme.palette.grey[400]}`}
               borderRadius={4}
             >
-              <Typography
-                component={"span"}
-                sx={{ color: theme.palette.grey[500] }}
-                fontSize={12}
-                ml={folders.length < 2 ? 0 : 1}
-              >
-                {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
-              </Typography>
-              <Box
-                display={"flex"}
-                flexDirection={"row"}
-                flexWrap={"wrap"}
-                gap={1}
-                mt={0.5}
-              >
-                {!isFoldersEmpty &&
-                  folders.map((folder) => (
-                    // TODO: 後でリファクタする
-                    <Button
-                      key={folder.folderUUID}
-                      onClick={() => {
-                        setSelectedFolderUUID(folder.folderUUID);
-                        onClose();
-                      }}
-                      sx={{
-                        ...label,
-                        bgcolor:
-                          selectedFolderUUID === folder.folderUUID
-                            ? theme.palette.primary.main
-                            : "white"
-                      }}
-                    >
-                      <Typography fontSize={12}>{folder.name}</Typography>
-                    </Button>
-                  ))}
-              </Box>
+              <FolderPopupContent
+                folders={folders}
+                isFoldersEmpty={isFoldersEmpty}
+                selectedFolderUUID={selectedFolderUUID}
+                setSelectedFolderUUID={setSelectedFolderUUID}
+                onClose={onClose}
+              />
             </Box>
           </Fade>
         )}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -2,6 +2,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import FolderIcon from "@mui/icons-material/Folder";
 import { Box, Fade, Popper, Typography } from "@mui/material";
 import type { Folder } from "@/src/api/folder-api";
+import { NotFoundFolder } from "./NotFolder";
 import { Button } from "@/src/components/button";
 import { theme } from "@/src/utils/theme";
 
@@ -98,41 +99,46 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
               border={`1px solid ${theme.palette.grey[400]}`}
               borderRadius={4}
             >
-              <Typography
-                component={"span"}
-                sx={{ color: theme.palette.grey[500] }}
-                fontSize={12}
-                ml={folders.length < 2 ? 0 : 1}
-              >
-                {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
-              </Typography>
-              <Box
-                display={"flex"}
-                flexDirection={"row"}
-                flexWrap={"wrap"}
-                gap={1}
-                mt={0.5}
-              >
-                {!isFoldersEmpty &&
-                  folders.map((folder) => (
-                    <Button
-                      key={folder.folderUUID}
-                      onClick={() => {
-                        setSelectedFolderUUID(folder.folderUUID);
-                        onClose();
-                      }}
-                      sx={{
-                        ...label,
-                        bgcolor:
-                          selectedFolderUUID === folder.folderUUID
-                            ? theme.palette.primary.main
-                            : "white"
-                      }}
-                    >
-                      <Typography fontSize={12}>{folder.name}</Typography>
-                    </Button>
-                  ))}
-              </Box>
+              {isFoldersEmpty ? (
+                <NotFoundFolder />
+              ) : (
+                <>
+                  <Typography
+                    component={"span"}
+                    sx={{ color: theme.palette.grey[500] }}
+                    fontSize={12}
+                    ml={folders.length === 1 ? 0 : 1}
+                  >
+                    1つ選択できます
+                  </Typography>
+                  <Box
+                    display={"flex"}
+                    flexDirection={"row"}
+                    flexWrap={"wrap"}
+                    gap={1}
+                    mt={0.5}
+                  >
+                    {folders.map((folder) => (
+                      <Button
+                        key={folder.folderUUID}
+                        onClick={() => {
+                          setSelectedFolderUUID(folder.folderUUID);
+                          onClose();
+                        }}
+                        sx={{
+                          ...label,
+                          bgcolor:
+                            selectedFolderUUID === folder.folderUUID
+                              ? theme.palette.primary.main
+                              : "white"
+                        }}
+                      >
+                        <Typography fontSize={12}>{folder.name}</Typography>
+                      </Button>
+                    ))}
+                  </Box>
+                </>
+              )}
             </Box>
           </Fade>
         )}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -100,6 +100,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
               borderRadius={4}
             >
               {isFoldersEmpty ? (
+                // TODO: ファイル名を変更する
                 <NotFoundFolder />
               ) : (
                 <>

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -38,7 +38,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
 
   return (
     <>
-      <Box display="flex" alignItems="center">
+      <Box display={"flex"} alignItems={"center"}>
         <Button
           onClick={onPopupOpen}
           sx={{

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -91,7 +91,8 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
             <Box
-              p={1}
+              px={1}
+              py={isFoldersEmpty ? 0.5 : 1}
               maxWidth="250px"
               bgcolor="#f8fbff"
               border={`1px solid ${theme.palette.grey[400]}`}
@@ -101,7 +102,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
                 component={"span"}
                 sx={{ color: theme.palette.grey[500] }}
                 fontSize={12}
-                ml={1}
+                ml={folders.length < 2 ? 0 : 1}
               >
                 {isFoldersEmpty ? "フォルダがありません" : "1つ選択できます"}
               </Typography>

--- a/src/features/routes/post/popup/folder-setting/NotFolder.tsx
+++ b/src/features/routes/post/popup/folder-setting/NotFolder.tsx
@@ -1,0 +1,14 @@
+import { Typography } from "@mui/material";
+import { theme } from "@/src/utils/theme";
+
+export const NotFoundFolder: React.FC = () => {
+  return (
+    <Typography
+      component={"span"}
+      sx={{ color: theme.palette.grey[500] }}
+      fontSize={12}
+    >
+      フォルダがありません
+    </Typography>
+  );
+};


### PR DESCRIPTION
## やったこと
- フォルダがないとき、「フォルダがありません」と表示
## 動作確認動画(スクリーンショット)
<img width="235" alt="image" src="https://github.com/user-attachments/assets/a411e459-ea6e-4455-812c-26a79537bddf" />
<img width="215" alt="image" src="https://github.com/user-attachments/assets/12e106c4-253a-4a7c-98f1-3675997de88c" />

<img width="278" alt="image" src="https://github.com/user-attachments/assets/4a96a535-f2b3-4790-924d-3fc7f2c2d0b3" />



## 確認したこと(デグレチェック)
- 自分のフォルダがないとき、「フォルダがありません」と表示
- フォルダがあるとき、「1つ選択できます」と表示されてフォルダが選択できる
## リリース時本番環境で確認すること
- フォルダがないときの挙動が正しいかどうか