### PR TITLE
disablePortalを追加し無駄なレンダリングを防ぎ軽いバグを解消する

### DIFF
--- a/src/features/common/kebab-button-popup/KebabMenuButton.tsx
+++ b/src/features/common/kebab-button-popup/KebabMenuButton.tsx
@@ -73,6 +73,7 @@ export const KebabMenuButton: React.FC<KebabMenuButtonProps> = ({
         />
       </Box>
       <Popper
+        disablePortal
         open={open}
         anchorEl={anchorEl}
         transition
@@ -80,7 +81,7 @@ export const KebabMenuButton: React.FC<KebabMenuButtonProps> = ({
       >
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
-            <Box boxShadow={1} borderRadius={2.5} bgcolor={"white"}>
+            <Box boxShadow={1} borderRadius={2.5} bgcolor={"white"} minWidth={"200px"}>
               {isReflectionSettingHeader ? (
                 <>
                   <PopupButton

--- a/src/features/common/kebab-button-popup/KebabMenuButton.tsx
+++ b/src/features/common/kebab-button-popup/KebabMenuButton.tsx
@@ -81,7 +81,7 @@ export const KebabMenuButton: React.FC<KebabMenuButtonProps> = ({
       >
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
-            <Box boxShadow={1} borderRadius={2.5} bgcolor={"white"} minWidth={"200px"}>
+            <Box boxShadow={1} borderRadius={2.5} bgcolor={"white"} minWidth={"185px"}>
               {isReflectionSettingHeader ? (
                 <>
                   <PopupButton

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -85,13 +85,13 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
           </Box>
         ) : null}
       </Box>
-      <Popper disablePortal open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
+      { /* TODO: disablePortal の動作を確認する */ }
+      <Popper open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
             <Box
               p={1}
               maxWidth="250px"
-              minWidth={"150px"}
               bgcolor="#f8fbff"
               border={`1px solid ${theme.palette.grey[400]}`}
               borderRadius={4}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -85,12 +85,13 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
           </Box>
         ) : null}
       </Box>
-      <Popper open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
+      <Popper disablePortal open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
             <Box
               p={1}
               maxWidth="250px"
+              minWidth={"150px"}
               bgcolor="#f8fbff"
               border={`1px solid ${theme.palette.grey[400]}`}
               borderRadius={4}

--- a/src/features/routes/post/popup/markdown-support/MarkdownSupportPopupArea.tsx
+++ b/src/features/routes/post/popup/markdown-support/MarkdownSupportPopupArea.tsx
@@ -83,6 +83,7 @@ const MarkdownSupportPopupArea: React.FC<MarkdownSupportPopupAreaProps> = ({
         />
       )}
       <Popper
+        disablePortal
         open={open}
         anchorEl={anchorEl}
         transition
@@ -123,6 +124,7 @@ const MarkdownSupportPopupArea: React.FC<MarkdownSupportPopupAreaProps> = ({
                 }
               }}
               onClick={(e) => e.stopPropagation()}
+              minWidth={"300px"}
             >
               {markdownList.map((markdown) => (
                 <MarkdownSection

--- a/src/features/routes/post/popup/publish-setting/PublishSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/publish-setting/PublishSettingPopupArea.tsx
@@ -43,10 +43,10 @@ const PublishSettingPopupArea: React.FC<PublishSettingPopupAreaProps> = ({
         />
         {value ? "公開" : "非公開"}
       </Button>
-      <Popper open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
+      <Popper disablePortal open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
-            <Box boxShadow={1} borderRadius={2} bgcolor={"white"}>
+            <Box boxShadow={1} borderRadius={2} bgcolor={"white"} minWidth={"200px"}>
               <PublishStatusOptionButton
                 isActive={value}
                 onClick={() => {

--- a/src/features/routes/post/popup/reflection-template/ReflectionTemplatePopupArea.tsx
+++ b/src/features/routes/post/popup/reflection-template/ReflectionTemplatePopupArea.tsx
@@ -47,7 +47,7 @@ const ReflectionTemplatePopupArea: React.FC<
       >
         テンプレートを使う
       </Button>
-      <Popper open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
+      <Popper disablePortal open={open} anchorEl={anchorEl} transition sx={{ zIndex: 2 }}>
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={250}>
             <Box
@@ -70,6 +70,7 @@ const ReflectionTemplatePopupArea: React.FC<
                   backgroundColor: theme.palette.grey[600]
                 }
               }}
+              minWidth={"300px"}
             >
               {Object.keys(reflectionTemplateType).map((categoryKey) => (
                 <Fragment key={categoryKey}>

--- a/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
+++ b/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
@@ -70,8 +70,8 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
           </Box>
         ))}
       </Box>
+      { /* TODO: disablePortal の動作を確認する */ }
       <Popper
-        disablePortal
         open={open}
         anchorEl={anchorEl}
         transition
@@ -94,7 +94,6 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
               bgcolor="#f8fbff"
               border={`1px solid ${theme.palette.grey[400]}`}
               borderRadius={4}
-              minWidth={"200px"}
             >
               <Typography
                 component={"span"}

--- a/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
+++ b/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
@@ -71,6 +71,7 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
         ))}
       </Box>
       <Popper
+        disablePortal
         open={open}
         anchorEl={anchorEl}
         transition
@@ -93,6 +94,7 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
               bgcolor="#f8fbff"
               border={`1px solid ${theme.palette.grey[400]}`}
               borderRadius={4}
+              minWidth={"200px"}
             >
               <Typography
                 component={"span"}

--- a/src/features/routes/reflection-detail/header/HeaderTableOfContents.tsx
+++ b/src/features/routes/reflection-detail/header/HeaderTableOfContents.tsx
@@ -44,6 +44,7 @@ const HeaderTableOfContents: React.FC<HeaderTableOfContentsProps> = ({
         目次
       </Button>
       <Popper
+        disablePortal
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}
         transition

--- a/src/features/routes/reflection-detail/header/HeaderTableOfContents.tsx
+++ b/src/features/routes/reflection-detail/header/HeaderTableOfContents.tsx
@@ -43,8 +43,8 @@ const HeaderTableOfContents: React.FC<HeaderTableOfContentsProps> = ({
       >
         目次
       </Button>
+      { /* TODO: disablePortal の動作を確認する */ }
       <Popper
-        disablePortal
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}
         transition


### PR DESCRIPTION
## やったこと
7箇所のpopupを使用しているところに,disablePortalとminWidthをつけた
## 動作確認動画(スクリーンショット)
1.kebab-menu-button
- 修正前
https://github.com/user-attachments/assets/fbb7e0cb-3e43-477d-904a-d202e239ea24
- 修正後
https://github.com/user-attachments/assets/c0e8832b-8e45-4cae-b980-bc0d8f378e08
2. post folder-setting
- 修正前
https://github.com/user-attachments/assets/6c7d63c2-f0f5-4d2c-8b4b-648d269cf543
- 修正後
https://github.com/user-attachments/assets/74b52841-0acc-4c92-b0e5-1d88b77cc9cf
3.post markdown 
- 修正前
https://github.com/user-attachments/assets/b6e6420b-3ca4-4ae1-8b71-24d5a2b03521
- 修正後
4.post publish-setting
- 修正前
https://github.com/user-attachments/assets/2483c357-a644-4ef1-b212-eaca04c18141
- 修正後
https://github.com/user-attachments/assets/f8224fcb-af41-4823-9df8-92d9c82c02e3
5.post reflection-template
- 修正前 
https://github.com/user-attachments/assets/3a3f1dc7-2d8b-4d88-b34d-bad2acd4835c
- 修正後
https://github.com/user-attachments/assets/bb0e0eba-1fd5-4451-9adb-9e95d848de7f
6.post select-tag 
- 修正前
https://github.com/user-attachments/assets/e231407b-147a-4cb0-932a-1a2426dad8e0
- 修正後
https://github.com/user-attachments/assets/c32d43d7-a70c-4ca6-a6ac-bdac744513c2
7.header-tab (目次)
- 修正前
https://github.com/user-attachments/assets/e34961c8-0670-4644-8439-7131bcb834c5
- 修正後
https://github.com/user-attachments/assets/c114b57b-5000-4937-9d4b-face3226aa7c
## 確認したこと(デグレチェック)
修正したことによるレンダリングの変化
1.kebab-menu-button
改善
2.post folder-setting
変化なし
3.post markdown
右に移動
4.post publish-setting
改善
5.reflection-template
改善
6.post select-tag
変化なし
7.header-tab (目次)
変化なし
## リリース時本番環境で確認すること

