### PR TITLE
フォルダ名を更新したときにエラーで落ちてしまうのを修正

### DIFF
--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -67,6 +67,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     }
     setIsEditFieldOpen(false);
     onFolderUpdate(updatedFolder);
+    onRefetch(username);
   };
 
   const Content = (

--- a/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
+++ b/src/features/routes/reflection-list/sidebar/item/FolderItem.tsx
@@ -103,7 +103,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
             noWrap: true,
             maxWidth: "100px"
           }}
-          secondary={count.toString()}
+          secondary={count?.toString()}
           secondaryTypographyProps={{
             className: "secondary-text",
             sx: {


### PR DESCRIPTION
## やったこと
- フォルダ名を更新したときのエラーを修正
## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/a03f0252-8fcc-4c28-b5e3-0d59696812a2


## 確認したこと(デグレチェック)

## リリース時本番環境で確認すること
