### PR TITLE
投稿ページでユーザーが何か入力した時、ページを離れようとするとアラートダイアログを出すようにする

### DIFF
--- a/src/app/(base-footer)/post/page.client.tsx
+++ b/src/app/(base-footer)/post/page.client.tsx
@@ -2,6 +2,7 @@
 import type { Folder } from "@/src/api/folder-api";
 import ReflectionPostForm from "@/src/features/common/post-form/ReflectionPostForm";
 import { useCreateReflectionForm } from "@/src/hooks/reflection/useCreateReflectionForm";
+import { useWarningDialog } from "@/src/hooks/reflection/useWarningDialog";
 
 type ReflectionPostFormPageProps = {
   username: string;
@@ -14,6 +15,7 @@ const ReflectionPostFormPage: React.FC<ReflectionPostFormPageProps> = ({
 }) => {
   const {
     control,
+    isDirty,
     isSubmitting,
     isSubmitSuccessful,
     errors,
@@ -24,6 +26,8 @@ const ReflectionPostFormPage: React.FC<ReflectionPostFormPageProps> = ({
     handleFolderChange,
     handleTagChange
   } = useCreateReflectionForm(username);
+
+  useWarningDialog(isDirty, isSubmitSuccessful);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/hooks/reflection/useCreateReflectionForm.ts
+++ b/src/hooks/reflection/useCreateReflectionForm.ts
@@ -40,7 +40,7 @@ export const useCreateReflectionForm = (username: string | undefined) => {
     handleSubmit,
     control,
     setValue,
-    formState: { isSubmitting, isSubmitSuccessful, errors }
+    formState: { isDirty, isSubmitting, isSubmitSuccessful, errors }
   } = useForm<CreateReflectionSchemaType>({
     resolver: zodResolver(createReflectionSchema),
     defaultValues: {
@@ -95,6 +95,7 @@ export const useCreateReflectionForm = (username: string | undefined) => {
 
   return {
     control,
+    isDirty,
     isSubmitting,
     isSubmitSuccessful,
     errors,

--- a/src/hooks/reflection/useWarningDialog.ts
+++ b/src/hooks/reflection/useWarningDialog.ts
@@ -1,0 +1,32 @@
+// hooks/useUnsavedChangesWarning.ts
+import { useEffect, useState } from "react";
+
+export const useWarningDialog = (
+  isDirty: boolean,
+  isSubmitSuccessful: boolean
+) => {
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  // NOTE: 投稿ページで変更があった場合、または投稿が成功していない場合にhasUnsavedChangesをtrueにする
+  useEffect(() => {
+    if (isDirty && !isSubmitSuccessful) {
+      setHasUnsavedChanges(true);
+    } else {
+      setHasUnsavedChanges(false);
+    }
+  }, [isDirty, isSubmitSuccessful]);
+
+  // NOTE: ページを離れる際に警告ダイアログを表示する
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [hasUnsavedChanges]);
+
+  return hasUnsavedChanges;
+};


### PR DESCRIPTION
## やったこと
- window.addEventListener("beforeunload", "")を使ってダイアログを出す
  - 変更がない場合はダイアログが出ない
  - 1つでも変更がある場合はダイアログが出る

参考: https://developer.mozilla.org/ja/docs/Web/API/Window/beforeunload_event

## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/7b71bb74-0a96-4467-9d9f-874351184cb9


## 確認したこと(デグレチェック)
- 正常に投稿ができること
- ページを離れるボタンを押したら意図したページ遷移が行われること

## リリース時本番環境で確認すること
- PWAでの挙動