### PR TITLE
投稿に関心を持つテストを追加

### DIFF
--- a/e2e/mocks/reflection/reflection.ts
+++ b/e2e/mocks/reflection/reflection.ts
@@ -1,0 +1,12 @@
+export const requestReflection = {
+  title: "テストのtitle",
+  content: "テストのcontent",
+  charStamp: "💭",
+  isPublic: false,
+  isDailyReflection: false,
+  isLearning: false,
+  isAwareness: false,
+  isInputLog: false,
+  isMonologue: false,
+  folderUUID: null
+};

--- a/e2e/tests/api/post-reflection-api.spec.ts
+++ b/e2e/tests/api/post-reflection-api.spec.ts
@@ -1,0 +1,31 @@
+import { expect, request, test } from "@playwright/test";
+import { authSessionCookie } from "@/e2e/mocks/auth/authSessionCookie";
+import { requestReflection } from "@/e2e/mocks/reflection/reflection";
+
+test.describe("未認証ユーザー", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test("リクエストが拒否され、401エラーが返される", async () => {
+    const apiContext = await request.newContext();
+    const response = await apiContext.post("/api/reflection", {
+      data: requestReflection
+    });
+
+    expect(response.status()).toBe(401);
+  });
+});
+
+test.describe("認証済みユーザー", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().addCookies([authSessionCookie]);
+  });
+
+  test("リクエストが許可され、201が返る", async ({ page }) => {
+    const response = await page.request.post("/api/reflection", {
+      data: requestReflection
+    });
+    expect(response.status()).toBe(201);
+  });
+});

--- a/e2e/tests/api/post-reflection-api.spec.ts
+++ b/e2e/tests/api/post-reflection-api.spec.ts
@@ -1,4 +1,4 @@
-import { expect, request, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { authSessionCookie } from "@/e2e/mocks/auth/authSessionCookie";
 import { requestReflection } from "@/e2e/mocks/reflection/reflection";
 
@@ -7,12 +7,10 @@ test.describe("未認証ユーザー", () => {
     await page.context().clearCookies();
   });
 
-  test("リクエストが拒否され、401エラーが返される", async () => {
-    const apiContext = await request.newContext();
-    const response = await apiContext.post("/api/reflection", {
+  test("リクエストが拒否され、401エラーが返される", async ({ page }) => {
+    const response = await page.request.post("/api/reflection", {
       data: requestReflection
     });
-
     expect(response.status()).toBe(401);
   });
 });

--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -3,7 +3,6 @@ import { authSessionCookie } from "@/e2e/mocks/auth/authSessionCookie";
 
 test.describe("未認証ユーザー", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
     await page.context().clearCookies();
   });
 
@@ -17,8 +16,6 @@ test.describe("未認証ユーザー", () => {
 
 test.describe("認証済みユーザー", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    // NOTE:ログイン状態を再現するためにモックの認証クッキーを追加
     await page.context().addCookies([authSessionCookie]);
   });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,8 +5,6 @@ import dotenv from "dotenv";
 dotenv.config({ path: path.resolve(__dirname, ".env") });
 
 export default defineConfig({
-  testDir: "./e2e/tests",
-
   fullyParallel: true,
 
   forbidOnly: !!process.env.CI,
@@ -26,25 +24,55 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      testDir: "./e2e/tests/api",
+      use: { ...devices["Desktop Chrome"] }
+    },
+    {
+      name: "chromium",
+      testDir: "./e2e/tests/ui",
       use: { ...devices["Desktop Chrome"] }
     },
 
     {
       name: "webkit",
+      testDir: "./e2e/tests/api",
+      use: { ...devices["Desktop Safari"] }
+    },
+    {
+      name: "webkit",
+      testDir: "./e2e/tests/ui",
       use: { ...devices["Desktop Safari"] }
     },
 
     {
       name: "Mobile Chrome",
+      testDir: "./e2e/tests/api",
+      use: { ...devices["Pixel 5"] }
+    },
+    {
+      name: "Mobile Chrome",
+      testDir: "./e2e/tests/ui",
       use: { ...devices["Pixel 5"] }
     },
     {
       name: "Mobile Safari",
+      testDir: "./e2e/tests/api",
+      use: { ...devices["iPhone 12"] }
+    },
+    {
+      name: "Mobile Safari",
+      testDir: "./e2e/tests/ui",
       use: { ...devices["iPhone 12"] }
     },
 
     {
       name: "Google Chrome",
+      testDir: "./e2e/tests/api",
+      use: { ...devices["Desktop Chrome"], channel: "chrome" }
+    },
+    {
+      name: "Google Chrome",
+      testDir: "./e2e/tests/ui",
       use: { ...devices["Desktop Chrome"], channel: "chrome" }
     }
   ],


### PR DESCRIPTION
## やったこと
- testsディレクトリの中に以下二つのディレクトリを作成
  - api
  - ui
- 上述に沿ったtestDirを設定
- requestReflectionを作成
  - ほんとはreflectionという名前にしたかったが、UUID等はないあくまでリクエスト送る時のdataなのでそのような命名にした

## 確認したこと(デグレチェック)
- CIが通ること