### PR TITLE
titleとcontentに文字を入力し投稿した時、自身の投稿一覧ページにリダイレクトされるテストを追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,8 @@
     "googleusercontent",
     "opengraph",
     "supabase",
-    "REFTY"
+    "REFTY",
+    "networkidle"
   ],
 
   "editor.tabSize": 2,

--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -17,10 +17,20 @@ test.describe("未認証ユーザー", () => {
 test.describe("認証済みユーザー", () => {
   test.beforeEach(async ({ page }) => {
     await page.context().addCookies([authSessionCookie]);
+    await page.goto("/post");
   });
 
   test("投稿ページに正常にアクセスできる", async ({ page }) => {
-    await page.goto("/post");
     expect(page.url()).toContain("/post");
+  });
+
+  test("titleとcontentに文字を入力し投稿した時、自身の投稿一覧ページにリダイレクトされる", async ({
+    page
+  }) => {
+    (await page.waitForSelector("input#title")).fill("テストのtitle");
+    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("button[type='submit']").click();
+    await page.waitForLoadState("networkidle");
+    expect(page.url()).toContain("/test");
   });
 });

--- a/src/app/api/reflection/route.ts
+++ b/src/app/api/reflection/route.ts
@@ -40,6 +40,10 @@ export async function POST(req: NextRequest) {
     if (!currentUser?.id) {
       return unauthorizedError("認証されていません");
     }
+
+    if (process.env.NEXT_PUBLIC_APP_ENV === "playwright") {
+      return NextResponse.json({ id: "dummy-id", ...body }, { status: 201 });
+    }
     const reflection = await reflectionService.create({
       ...body,
       userId: currentUser.id


### PR DESCRIPTION
## やったこと
- 「titleとcontentに文字を入力し投稿した時、自身の投稿一覧ページにリダイレクトされる」テストの作成
- 投稿APIテストで現状テストが回るたびにDBにinsertされてしまっているのでhotfixで修正
- networkidleをtypoと認識されないようにする

## 確認したこと(デグレチェック)
- CIが通ること
- playwightの非同期処理周りのテストで非推奨メソッドを避けたこと
