### PR TITLE
titleが40文字を超えた状態で投稿ボタンを押すと、エラーメッセージが表示されるテストを追加

### DIFF
--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -45,4 +45,15 @@ test.describe("認証済みユーザー", () => {
       page.locator("text=タイトルは1文字以上で入力してください。")
     ).toBeVisible();
   });
+
+  test("titleが40文字を超えた状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
+    page
+  }) => {
+    (await page.waitForSelector("input#title")).fill("a".repeat(41));
+    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("button[type='submit']").click();
+    await expect(
+      page.locator("text=タイトルは40文字以内で入力してください。")
+    ).toBeVisible();
+  });
 });

--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -56,4 +56,34 @@ test.describe("認証済みユーザー", () => {
       page.locator("text=タイトルは40文字以内で入力してください。")
     ).toBeVisible();
   });
+
+  test("titleが空白文字のみの状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
+    page
+  }) => {
+    (await page.waitForSelector("input#title")).fill(" ");
+    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("button[type='submit']").click();
+    await expect(
+      page.locator("text=タイトルは1文字以上で入力してください。")
+    ).toBeVisible();
+  });
+
+  test("contentが未入力の状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
+    page
+  }) => {
+    (await page.waitForSelector("input#title")).fill("テストのtitle");
+    await page.locator("button[type='submit']").click();
+    await expect(
+      page.locator("text=1文字以上入力してください。")
+    ).toBeVisible();
+  });
+
+  test("投稿ボタンを押すと、投稿し終わるまでボタンが非活性になっている", async ({
+    page
+  }) => {
+    (await page.waitForSelector("input#title")).fill("テストのtitle");
+    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("button[type='submit']").click();
+    await expect(page.locator("button[type='submit']")).toBeDisabled();
+  });
 });

--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -25,7 +25,7 @@ test.describe("認証済みユーザー", () => {
     expect(page.url()).toContain("/post");
   });
 
-  test("titleとcontentに文字を入力し投稿した時、自身の投稿一覧ページにリダイレクトされる", async ({
+  test("titleとcontentに文字が入力された状態で投稿ボタンを押すと、自身の投稿一覧ページにリダイレクトされる", async ({
     page
   }) => {
     (await page.waitForSelector("input#title")).fill("テストのtitle");
@@ -36,7 +36,7 @@ test.describe("認証済みユーザー", () => {
     expect(page.url()).toContain(jwt?.username);
   });
 
-  test("titleが未入力の状態で投稿ボタンを押すとエラーメッセージが表示される", async ({
+  test("titleが未入力の状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
     page
   }) => {
     (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");

--- a/src/hooks/reflection/useCreateReflectionForm.ts
+++ b/src/hooks/reflection/useCreateReflectionForm.ts
@@ -12,11 +12,9 @@ export const createReflectionSchema = z.object({
     .min(1, { message: "タイトルは1文字以上で入力してください。" })
     .max(40, { message: "タイトルは40文字以内で入力してください。" })
     .refine((value) => value.trim().length > 0, {
-      message: "空白のみのタイトルはできません。"
+      message: "タイトルは1文字以上で入力してください。"
     }),
-  content: z
-    .string()
-    .min(1, { message: "本文は1文字以上で入力してください。" }),
+  content: z.string().min(1, { message: "1文字以上入力してください。" }),
   charStamp: z.string(),
   isPublic: z.boolean(),
   isDailyReflection: z.boolean().default(false),


### PR DESCRIPTION
## やったこと
- titleが40文字を超えた状態で投稿ボタンを押すと、エラーメッセージが表示されるテストの作成
- テスト名の書き方を統一させる

## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/24b8e327-5096-4c2c-9c36-ad7e4c25a41e


ひとりごと: ブランチ名ミスった
