### PR TITLE
contentが未入力の状態で投稿ボタンを押すと、エラーメッセージが表示されるテストの追加

### DIFF
--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -74,7 +74,7 @@ test.describe("認証済みユーザー", () => {
     (await page.waitForSelector("input#title")).fill("テストのtitle");
     await page.locator("button[type='submit']").click();
     await expect(
-      page.locator("text=1文字以上で入力してください。")
+      page.locator("text=1文字以上入力してください。")
     ).toBeVisible();
   });
 });

--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -67,4 +67,14 @@ test.describe("認証済みユーザー", () => {
       page.locator("text=タイトルは1文字以上で入力してください。")
     ).toBeVisible();
   });
+
+  test("contentが未入力の状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
+    page
+  }) => {
+    (await page.waitForSelector("input#title")).fill("テストのtitle");
+    await page.locator("button[type='submit']").click();
+    await expect(
+      page.locator("text=1文字以上で入力してください。")
+    ).toBeVisible();
+  });
 });

--- a/src/hooks/reflection/useCreateReflectionForm.ts
+++ b/src/hooks/reflection/useCreateReflectionForm.ts
@@ -14,9 +14,7 @@ export const createReflectionSchema = z.object({
     .refine((value) => value.trim().length > 0, {
       message: "タイトルは1文字以上で入力してください。"
     }),
-  content: z
-    .string()
-    .min(1, { message: "本文は1文字以上で入力してください。" }),
+  content: z.string().min(1, { message: "1文字以上入力してください。" }),
   charStamp: z.string(),
   isPublic: z.boolean(),
   isDailyReflection: z.boolean().default(false),


### PR DESCRIPTION
## やったこと
- contentが未入力の状態で投稿ボタンを押すと、エラーメッセージが表示されるテストの作成
- バリデーションエラーメッセージを変更

## 動作確認動画(スクリーンショット)
https://github.com/user-attachments/assets/c57b60ff-10d3-423f-bbcc-9d05f82074a2

