### PR TITLE
投稿ボタンを押すと、投稿し終わるまでボタンが非活性になっているテストの追加

### DIFF
--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -77,4 +77,13 @@ test.describe("認証済みユーザー", () => {
       page.locator("text=1文字以上入力してください。")
     ).toBeVisible();
   });
+
+  test("投稿ボタンを押すと、投稿し終わるまでボタンが非活性になっている", async ({
+    page
+  }) => {
+    (await page.waitForSelector("input#title")).fill("テストのtitle");
+    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("button[type='submit']").click();
+    await expect(page.locator("button[type='submit']")).toBeDisabled();
+  });
 });


### PR DESCRIPTION
## やったこと
- 投稿ボタンを押すと、投稿し終わるまでボタンが非活性になっているテストの作成

## 動作確認動画(スクリーンショット)


https://github.com/user-attachments/assets/754aeb06-3f7f-4729-8c5b-0ddda0e36399

