### PR TITLE
waitForSelectorをlocator.waitFor()に置き換える

### DIFF
--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -29,7 +29,7 @@ test.describe("認証済みユーザー", () => {
     page
   }) => {
     await page.locator("input#title").fill("テストのtitle");
-    await page.fill(".tiptap.ProseMirror", "テストのcontent");
+    await page.locator(".tiptap.ProseMirror").fill("テストのcontent");
     await page.locator("button[type='submit']").click();
     await page.waitForLoadState("networkidle");
     const jwt = await authJwt.decode();
@@ -39,7 +39,7 @@ test.describe("認証済みユーザー", () => {
   test("titleが未入力の状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
     page
   }) => {
-    await page.fill(".tiptap.ProseMirror", "テストのcontent");
+    await page.locator(".tiptap.ProseMirror").fill("テストのcontent");
     await page.locator("button[type='submit']").click();
     await expect(
       page.locator("text=タイトルは1文字以上で入力してください。")
@@ -50,7 +50,7 @@ test.describe("認証済みユーザー", () => {
     page
   }) => {
     await page.locator("input#title").fill("a".repeat(41));
-    await page.fill(".tiptap.ProseMirror", "テストのcontent");
+    await page.locator(".tiptap.ProseMirror").fill("テストのcontent");
     await page.locator("button[type='submit']").click();
     await expect(
       page.locator("text=タイトルは40文字以内で入力してください。")
@@ -61,7 +61,7 @@ test.describe("認証済みユーザー", () => {
     page
   }) => {
     await page.locator("input#title").fill(" ");
-    await page.fill(".tiptap.ProseMirror", "テストのcontent");
+    await page.locator(".tiptap.ProseMirror").fill("テストのcontent");
     await page.locator("button[type='submit']").click();
     await expect(
       page.locator("text=タイトルは1文字以上で入力してください。")
@@ -82,7 +82,7 @@ test.describe("認証済みユーザー", () => {
     page
   }) => {
     await page.locator("input#title").fill("テストのtitle");
-    await page.fill(".tiptap.ProseMirror", "テストのcontent");
+    await page.locator(".tiptap.ProseMirror").fill("テストのcontent");
     await page.locator("button[type='submit']").click();
     await expect(page.locator("button[type='submit']")).toBeDisabled();
   });

--- a/e2e/tests/ui/post-reflection.spec.ts
+++ b/e2e/tests/ui/post-reflection.spec.ts
@@ -28,8 +28,8 @@ test.describe("認証済みユーザー", () => {
   test("titleとcontentに文字が入力された状態で投稿ボタンを押すと、自身の投稿一覧ページにリダイレクトされる", async ({
     page
   }) => {
-    (await page.waitForSelector("input#title")).fill("テストのtitle");
-    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("input#title").fill("テストのtitle");
+    await page.fill(".tiptap.ProseMirror", "テストのcontent");
     await page.locator("button[type='submit']").click();
     await page.waitForLoadState("networkidle");
     const jwt = await authJwt.decode();
@@ -39,7 +39,7 @@ test.describe("認証済みユーザー", () => {
   test("titleが未入力の状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
     page
   }) => {
-    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.fill(".tiptap.ProseMirror", "テストのcontent");
     await page.locator("button[type='submit']").click();
     await expect(
       page.locator("text=タイトルは1文字以上で入力してください。")
@@ -49,8 +49,8 @@ test.describe("認証済みユーザー", () => {
   test("titleが40文字を超えた状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
     page
   }) => {
-    (await page.waitForSelector("input#title")).fill("a".repeat(41));
-    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("input#title").fill("a".repeat(41));
+    await page.fill(".tiptap.ProseMirror", "テストのcontent");
     await page.locator("button[type='submit']").click();
     await expect(
       page.locator("text=タイトルは40文字以内で入力してください。")
@@ -60,8 +60,8 @@ test.describe("認証済みユーザー", () => {
   test("titleが空白文字のみの状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
     page
   }) => {
-    (await page.waitForSelector("input#title")).fill(" ");
-    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("input#title").fill(" ");
+    await page.fill(".tiptap.ProseMirror", "テストのcontent");
     await page.locator("button[type='submit']").click();
     await expect(
       page.locator("text=タイトルは1文字以上で入力してください。")
@@ -71,7 +71,7 @@ test.describe("認証済みユーザー", () => {
   test("contentが未入力の状態で投稿ボタンを押すと、エラーメッセージが表示される", async ({
     page
   }) => {
-    (await page.waitForSelector("input#title")).fill("テストのtitle");
+    await page.locator("input#title").fill("テストのtitle");
     await page.locator("button[type='submit']").click();
     await expect(
       page.locator("text=1文字以上入力してください。")
@@ -81,8 +81,8 @@ test.describe("認証済みユーザー", () => {
   test("投稿ボタンを押すと、投稿し終わるまでボタンが非活性になっている", async ({
     page
   }) => {
-    (await page.waitForSelector("input#title")).fill("テストのtitle");
-    (await page.waitForSelector(".tiptap.ProseMirror")).fill("テストのcontent");
+    await page.locator("input#title").fill("テストのtitle");
+    await page.fill(".tiptap.ProseMirror", "テストのcontent");
     await page.locator("button[type='submit']").click();
     await expect(page.locator("button[type='submit']")).toBeDisabled();
   });


### PR DESCRIPTION
## やったこと
- 以下の通り非推奨なので置き換え
<img width="912" alt="スクリーンショット 2025-03-08 17 57 58" src="https://github.com/user-attachments/assets/b65452d0-2162-4f46-b185-f6cc3a76db49" />
https://playwright.dev/docs/api/class-page#page-wait-for-selector

## 確認したこと(デグレチェック)
- CIが通ること