### PR TITLE
s3取り込みスクリプト変更/LookerStudioにおける可視化

### DIFF
--- a/lambda-function/backup-func/lambda_function.py
+++ b/lambda-function/backup-func/lambda_function.py
@@ -3,53 +3,97 @@ import os
 import psycopg2
 import boto3
 import datetime
+import csv
 
 
 def lambda_handler(event, context):
+    
     s3_client = boto3.client('s3')
+
     
-    db_url = os.environ.get('DATABASE_URL', 'postgresql://user:password@host:port/dbname')
+    db_url = os.getenv('DATABASE_URL')
     if not db_url:
-        return {
-            'statusCode': 500,
-            'body': 'DATABASE_URL 環境変数が設定されていません。'
-        }
-    
-    try:
-        conn = psycopg2.connect(db_url)
-        cur = conn.cursor()
-    except Exception as e:
-        return {
-            'statusCode': 500,
-            'body': f"データベース接続に失敗しました: {e}"
-        }
-    
+        return {'statusCode': 500, 'body': 'DATABASE_URL環境変数が設定されていません。'}
+
+    conn = psycopg2.connect(db_url)
+    cur = conn.cursor()
+
     table_names = ['Reflection', 'Account', 'User', 'ReflectionFolder']
     csv_file_names = ['Reflection.csv', 'Account.csv', 'User.csv', 'ReflectionFolder.csv']
     
-    today_str = datetime.date.today().isoformat()
-    Bucket = 'refty-backup-data'
-    
+    today = datetime.datetime.utcnow().strftime('%Y-%m-%d')
+
+    bucket = 'refty-backup-data'
+
     results = []
-    
-    for table_name, csv_file in zip(table_names, csv_file_names):
+
+    for table_name, csv_file_name in zip(table_names, csv_file_names):
         try:
             buffer = io.StringIO()
             sql = f'COPY "{table_name}" TO STDOUT WITH CSV HEADER'
             cur.copy_expert(sql, buffer)
             buffer.seek(0)
-            
-            Key = f"{today_str}/{csv_file}"
-            
-            s3_client.put_object(Bucket=Bucket, Key=Key, Body=buffer.getvalue())
-            results.append(f"{table_name} のデータが S3 の {Key} にアップロードされました。")
+
+            key_today = f'{today}/{csv_file_name}'
+            s3_client.put_object(Bucket=bucket, Key=key_today, Body=buffer.getvalue())
+            #Reflectionの場合、文字列カラムを文字数をカウントして保存
+            if table_name == 'Reflection':
+                buffer.seek(0)
+                csv_reader = csv.reader(buffer)
+                headers = next(csv_reader)
+                
+                content_index = None
+                title_index = None
+                ai_feedback_index = None
+                
+                try:
+                    content_index = headers.index('content')
+                except ValueError:
+                    pass
+                try:
+                    title_index = headers.index('title')
+                except ValueError:
+                    pass
+                try:
+                    ai_feedback_index = headers.index('aiFeedback')
+                except ValueError:
+                    
+                    pass
+                
+                
+                new_buffer = io.StringIO()
+                csv_writer = csv.writer(new_buffer)
+                csv_writer.writerow(headers)  
+                
+                
+                for row in csv_reader:
+                    new_row = row.copy()
+                    # 文字数をカウントして保存
+                    if content_index is not None and row[content_index]:
+                        new_row[content_index] = str(len(row[content_index]))
+                    
+                    if title_index is not None and row[title_index]:
+                        new_row[title_index] = str(len(row[title_index]))
+                    
+                    if ai_feedback_index is not None and row[ai_feedback_index]:
+                        new_row[ai_feedback_index] = str(len(row[ai_feedback_index]))
+                    
+                    csv_writer.writerow(new_row)
+                
+                new_buffer.seek(0)
+                latest_key = f'latest/{csv_file_name}'
+                s3_client.put_object(Bucket=bucket, Key=latest_key, Body=new_buffer.getvalue())
+            else:               
+                buffer.seek(0)
+                latest_key = f'latest/{csv_file_name}'
+                s3_client.put_object(Bucket=bucket, Key=latest_key, Body=buffer.getvalue())
+
+            results.append(f"{table_name} を {today} と latest に保存しました。")
+
         except Exception as e:
-            results.append(f"{table_name} のアップロードに失敗しました: {e}")
-    
+            results.append(f"{table_name} のアップロードエラー：{str(e)}")
+
     cur.close()
     conn.close()
-    
-    return {
-        'statusCode': 200,
-        'body': "\n".join(results)
-    }
+
+    return {'statusCode': 200, 'body': results}

--- a/lambda-function/backup-func/lambda_function.py
+++ b/lambda-function/backup-func/lambda_function.py
@@ -37,6 +37,7 @@ def lambda_handler(event, context):
             key_today = f'{today}/{csv_file_name}'
             s3_client.put_object(Bucket=bucket, Key=key_today, Body=buffer.getvalue())
             #Reflectionの場合、文字列カラムを文字数をカウントして保存
+            #TODO USerテーブルについてもユーザーが記入するところがあるので、そこを文字数カウントに修正した方がいい
             if table_name == 'Reflection':
                 buffer.seek(0)
                 csv_reader = csv.reader(buffer)


### PR DESCRIPTION
## やったこと
s3に入っているバックアップデータを取得し、BigQuery内に取り込んだのち、テーブルを結合させたビューを作成。
LookerStudioにてデータソースを結合データとしてデータ可視化を行った。
https://lookerstudio.google.com/reporting/f9976522-874e-4711-a664-51b09c8d4d56
### 修正点
・現状バックアップデータに保存されているディレクトリ形式(日付)ではBigQuery側で動的にS3URIを指定することができないため、静的な名前のディレクトリである「latest」というディレクトリを同時に作成。
ユーザーやAIが入力されるカラムについてはcsvを転送する際に予期せぬエスケープエラーが発生するため、文字列を文字数に変換したのちにlatestディレクトリに格納するようにした。(通常の日付ディレクトリにはそのままのデータが入っている)
その加工コードを追記した

・s3バックアップデータについては全てを保存しておく必要はないと感じたので、１週間分のみを保存するように変更。
## 動作確認動画(スクリーンショット)
レイアウト変更・何か他に分析して欲しい事項などあれば何なりとお申し付けください！！！
<img width="399" alt="image" src="https://github.com/user-attachments/assets/ca7facbb-5783-4a60-b064-a5893c45f7b5" />

## 共有事項
supabaseのテーブル構造を変更する際は一報ください！