### PR TITLE
時間帯ごとの投稿数を取得するAPIを作成

### DIFF
--- a/src/app/api/[username]/detail/reflection-time/route.ts
+++ b/src/app/api/[username]/detail/reflection-time/route.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { reflectionService } from "@/src/service/reflectionService";
+import { getUserIdByUsername } from "@/src/utils/actions/get-userId-by-username";
+import { internalServerError, notFoundError } from "@/src/utils/http-error";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { username: string } }
+) {
+  const username = params.username;
+
+  if (!username) {
+    return notFoundError("ユーザーネームが見つかりません");
+  }
+
+  const userId = await getUserIdByUsername(username);
+
+  if (!userId) {
+    return notFoundError("ユーザーが見つかりません");
+  }
+
+  try {
+    const reflectionsDateGroup =
+      await reflectionService.getReflectionsByHourGroup(userId);
+
+    if (!reflectionsDateGroup) {
+      return notFoundError("ユーザーの振り返りが見つかりません");
+    }
+
+    return NextResponse.json({
+      reflectionsDateGroup
+    });
+  } catch (error) {
+    return internalServerError("GET", "ユーザーの振り返り時間帯一覧", error);
+  }
+}

--- a/src/service/reflectionService.ts
+++ b/src/service/reflectionService.ts
@@ -312,6 +312,37 @@ export const reflectionService = {
       reflectionCUID,
       isPublic
     });
+  },
+
+  async getReflectionsByHourGroup(userId: string) {
+    const reflections =
+      await reflectionRepository.getReflectionsDateByUserId(userId);
+
+    // MEMO: 0-23時の時間帯を初期化
+    const hourlyCount = Array.from({ length: 24 }).reduce<
+      Record<number, number>
+    >(
+      (acc, _, index) => ({ ...acc, [index]: 0 }),
+      {} as Record<number, number>
+    );
+
+    // MEMO: 各投稿の時間帯をカウント
+    reflections.forEach((reflection) => {
+      const hour = reflection.createdAt.getUTCHours();
+      hourlyCount[hour]++;
+    });
+
+    // MEMO: 時間帯ごとの投稿数を配列形式に変換
+    const hourlyReflections = Object.entries(hourlyCount).map(
+      ([hour, count]) => ({
+        hour: parseInt(hour),
+        count
+      })
+    );
+
+    return {
+      hourlyReflections
+    };
   }
 };
 

--- a/src/service/reflectionService.ts
+++ b/src/service/reflectionService.ts
@@ -340,9 +340,7 @@ export const reflectionService = {
       })
     );
 
-    return {
-      hourlyReflections
-    };
+    return hourlyReflections;
   }
 };
 


### PR DESCRIPTION
## やったこと
- 時間帯ごとの投稿数を取得するAPIを作成
## 動作確認動画(スクリーンショット)
＜戻り値例＞
```
[
  { hour: 0, count: 0 },  { hour: 1, count: 0 },
  { hour: 2, count: 1 },  { hour: 3, count: 1 },
  { hour: 4, count: 0 },  { hour: 5, count: 0 },
  { hour: 6, count: 0 },  { hour: 7, count: 0 },
  { hour: 8, count: 0 },  { hour: 9, count: 0 },
  { hour: 10, count: 0 }, { hour: 11, count: 0 },
  { hour: 12, count: 1 }, { hour: 13, count: 2 },
  { hour: 14, count: 1 }, { hour: 15, count: 0 },
  { hour: 16, count: 2 }, { hour: 17, count: 4 },
  { hour: 18, count: 0 }, { hour: 19, count: 0 },
  { hour: 20, count: 0 }, { hour: 21, count: 1 },
  { hour: 22, count: 3 }, { hour: 23, count: 1 }
]
```
## 確認したこと(デグレチェック)

## リリース時本番環境で確認すること
