### PR TITLE
isSmallScreenを内製化

### DIFF
--- a/src/app/(multi-footer)/[username]/book/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/book/page.client.tsx
@@ -13,7 +13,7 @@ import { SwipeIconDisplay } from "@/src/features/routes/reflections-book/SwipeIc
 import "@/src/features/routes/reflections-book/my-swiper.css";
 import { useParseTagsToValue } from "@/src/hooks/reflection-tag/useParseTagsToValue";
 import { useSwipeIconVisibility } from "@/src/hooks/reflections-book/useSwipeIconVisibility";
-import useIsMobile from "@/src/hooks/responsive/useIsMobile";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 type ReflectionsBookPageProps = {

--- a/src/app/(multi-footer)/[username]/book/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/book/page.client.tsx
@@ -5,7 +5,7 @@ import "swiper/css/navigation";
 import { EffectCards, Navigation } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import FolderIcon from "@mui/icons-material/Folder";
-import { Box, Typography, useMediaQuery } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import type { ReflectionBook } from "@/src/api/reflections-book-api";
 import { EmptyReflection } from "@/src/features/common/empty-reflection";
 import { ReflectionArticle } from "@/src/features/routes/reflection-detail/article";
@@ -13,6 +13,7 @@ import { SwipeIconDisplay } from "@/src/features/routes/reflections-book/SwipeIc
 import "@/src/features/routes/reflections-book/my-swiper.css";
 import { useParseTagsToValue } from "@/src/hooks/reflection-tag/useParseTagsToValue";
 import { useSwipeIconVisibility } from "@/src/hooks/reflections-book/useSwipeIconVisibility";
+import useIsMobile from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 type ReflectionsBookPageProps = {
@@ -30,7 +31,7 @@ const ReflectionsBookPage: React.FC<ReflectionsBookPageProps> = ({
   foldername,
   count
 }) => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
   const isVisible = useSwipeIconVisibility();
   const { parseTagsToValue } = useParseTagsToValue();
 
@@ -75,8 +76,8 @@ const ReflectionsBookPage: React.FC<ReflectionsBookPageProps> = ({
         modules={[EffectCards, Navigation]}
         cardsEffect={{
           slideShadows: false,
-          perSlideRotate: isSmallScreen ? 0 : 2,
-          perSlideOffset: isSmallScreen ? 0 : 8
+          perSlideRotate: isMobile ? 0 : 2,
+          perSlideOffset: isMobile ? 0 : 8
         }}
         navigation
       >

--- a/src/components/footer/default/DefaultFooter.tsx
+++ b/src/components/footer/default/DefaultFooter.tsx
@@ -4,7 +4,7 @@ import { useSession } from "next-auth/react";
 import { Box, Container, Typography } from "@mui/material";
 import { LogoutButton } from "../../../features/routes/login";
 import { CustomLink } from "./CustomLink";
-import useIsMobile from "@/src/hooks/responsive/useIsMobile";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 export const DefaultFooter = () => {

--- a/src/components/footer/default/DefaultFooter.tsx
+++ b/src/components/footer/default/DefaultFooter.tsx
@@ -1,14 +1,15 @@
 "use client";
 import Image from "next/image";
 import { useSession } from "next-auth/react";
-import { Box, Container, Typography, useMediaQuery } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 import { LogoutButton } from "../../../features/routes/login";
 import { CustomLink } from "./CustomLink";
+import useIsMobile from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 export const DefaultFooter = () => {
   const { data: session } = useSession();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
 
   return (
     <Box
@@ -42,7 +43,7 @@ export const DefaultFooter = () => {
               >
                 日々の振り返りを手助けする振り返りアプリ
               </Typography>
-              {!isSmallScreen && session && <LogoutButton />}
+              {!isMobile && session && <LogoutButton />}
             </Box>
             <Box display={"flex"} gap={8}>
               <Box display={"flex"} flexDirection={"column"} gap={2}>
@@ -63,7 +64,7 @@ export const DefaultFooter = () => {
                 )}
               </Box>
             </Box>
-            {isSmallScreen && session && (
+            {isMobile && session && (
               <Box mt={8}>
                 <LogoutButton />
               </Box>

--- a/src/features/routes/reflection-detail/article/ai-feedback/AIFeedbackAreaContainer.tsx
+++ b/src/features/routes/reflection-detail/article/ai-feedback/AIFeedbackAreaContainer.tsx
@@ -1,10 +1,5 @@
 import { IoArrowUndoSharp } from "react-icons/io5";
-import {
-  AccordionDetails,
-  Box,
-  Typography,
-  useMediaQuery
-} from "@mui/material";
+import { AccordionDetails, Box, Typography } from "@mui/material";
 import type { AIFeedbackType } from "@/src/api/send-to-sqs-api";
 import { AICalling } from "./AICalling";
 import { AIFeedbackArea } from "./AIFeedbackArea";
@@ -12,6 +7,7 @@ import { SelectAITypePopupAreaContainer } from "./SelectAITypePopupAreaContainer
 import { Accordion, AccordionSummary } from "@/src/components/accordion";
 import { Button } from "@/src/components/button";
 import { useAIFeedbackHandler } from "@/src/hooks/ai-feedback/useAIFeedbackHandler";
+import useIsMobile from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 type AIFeedbackAreaContainerProps = {
@@ -43,7 +39,7 @@ export const AIFeedbackAreaContainer: React.FC<
     handleSendToSQS
   } = useAIFeedbackHandler(reflectionCUID, aiFeedback, content, onSendToSQS);
 
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
 
   return (
     <Accordion>
@@ -55,8 +51,8 @@ export const AIFeedbackAreaContainer: React.FC<
       <AccordionDetails sx={{ py: 0.5, px: 0 }}>
         <Box
           display={"flex"}
-          flexDirection={isSmallScreen ? "column-reverse" : "row"}
-          gap={isSmallScreen ? 2 : 0}
+          flexDirection={isMobile ? "column-reverse" : "row"}
+          gap={isMobile ? 2 : 0}
         >
           <Button
             onClick={handleSendToSQS}
@@ -78,7 +74,7 @@ export const AIFeedbackAreaContainer: React.FC<
                 AIType={AIType}
               />
               <Box display={"flex"} alignItems={"center"}>
-                {!isSmallScreen && (
+                {!isMobile && (
                   <Box
                     component={IoArrowUndoSharp}
                     sx={{
@@ -89,7 +85,7 @@ export const AIFeedbackAreaContainer: React.FC<
                   />
                 )}
                 <Typography
-                  fontSize={isSmallScreen ? 13 : 15}
+                  fontSize={isMobile ? 13 : 15}
                   color={theme.palette.grey[600]}
                 >
                   AIのタイプを選択

--- a/src/features/routes/reflection-detail/article/ai-feedback/AIFeedbackAreaContainer.tsx
+++ b/src/features/routes/reflection-detail/article/ai-feedback/AIFeedbackAreaContainer.tsx
@@ -7,7 +7,7 @@ import { SelectAITypePopupAreaContainer } from "./SelectAITypePopupAreaContainer
 import { Accordion, AccordionSummary } from "@/src/components/accordion";
 import { Button } from "@/src/components/button";
 import { useAIFeedbackHandler } from "@/src/hooks/ai-feedback/useAIFeedbackHandler";
-import useIsMobile from "@/src/hooks/responsive/useIsMobile";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 type AIFeedbackAreaContainerProps = {

--- a/src/features/routes/reflection-detail/article/ai-feedback/SelectedAITypeButton.tsx
+++ b/src/features/routes/reflection-detail/article/ai-feedback/SelectedAITypeButton.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography } from "@mui/material";
-import useIsMobile from "@/src/hooks/responsive/useIsMobile";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 
 type SelectedAITypeButtonProps = {
   icon: string;

--- a/src/features/routes/reflection-detail/article/ai-feedback/SelectedAITypeButton.tsx
+++ b/src/features/routes/reflection-detail/article/ai-feedback/SelectedAITypeButton.tsx
@@ -1,5 +1,5 @@
-import { Box, Typography, useMediaQuery } from "@mui/material";
-import { theme } from "@/src/utils/theme";
+import { Box, Typography } from "@mui/material";
+import useIsMobile from "@/src/hooks/responsive/useIsMobile";
 
 type SelectedAITypeButtonProps = {
   icon: string;
@@ -11,14 +11,14 @@ export const SelectedAITypeButton: React.FC<SelectedAITypeButtonProps> = ({
 
   detail
 }) => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
   return (
     <>
       <Box
         display={"flex"}
         alignItems={"center"}
         gap={1}
-        fontSize={isSmallScreen ? 12 : 14}
+        fontSize={isMobile ? 12 : 14}
       >
         <Typography fontSize={20}>{icon}</Typography>
         {detail}

--- a/src/features/routes/welcome/first-view/FirstView.tsx
+++ b/src/features/routes/welcome/first-view/FirstView.tsx
@@ -1,9 +1,9 @@
-import { Box, Typography, useMediaQuery } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { Button } from "@/src/components/button";
-import { theme } from "@/src/utils/theme";
+import useIsMobile from "@/src/hooks/responsive/useIsMobile";
 
 const FirstView = () => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
 
   return (
     <Box
@@ -29,7 +29,7 @@ const FirstView = () => {
         lineHeight={1.8}
         fontSize={{ md: 18 }}
       >
-        {isSmallScreen ? (
+        {isMobile ? (
           <>
             リフティは、日々の気づきや感情を記録し、さまざまな人の多くの視点や価値観に触れることで新たな発見や自己成長を促す場所です。
           </>

--- a/src/features/routes/welcome/first-view/FirstView.tsx
+++ b/src/features/routes/welcome/first-view/FirstView.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import { Button } from "@/src/components/button";
-import useIsMobile from "@/src/hooks/responsive/useIsMobile";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 
 const FirstView = () => {
   const isMobile = useIsMobile();

--- a/src/features/routes/welcome/second-view/EffectSection.tsx
+++ b/src/features/routes/welcome/second-view/EffectSection.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { Box, Typography, useMediaQuery } from "@mui/material";
-import useIsMobile from "@/src/hooks/responsive/useIsMobile";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 type EffectSectionProps = {

--- a/src/features/routes/welcome/second-view/EffectSection.tsx
+++ b/src/features/routes/welcome/second-view/EffectSection.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { Box, Typography, useMediaQuery } from "@mui/material";
+import useIsMobile from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 type EffectSectionProps = {
@@ -20,7 +21,7 @@ const EffectSection: React.FC<EffectSectionProps> = ({
   isShareSection = false,
   isSmartphonePicture = false
 }) => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
   const isLarge = useMediaQuery(theme.breakpoints.up("xl"));
 
   return (
@@ -41,7 +42,7 @@ const EffectSection: React.FC<EffectSectionProps> = ({
         gap={5}
         my={{ xs: 6, md: 12 }}
       >
-        {!isSmallScreen && (
+        {!isMobile && (
           <Box
             bgcolor="#f3f4f5"
             display="flex"
@@ -68,7 +69,7 @@ const EffectSection: React.FC<EffectSectionProps> = ({
             />
           </Box>
         )}
-        {isSmartphonePicture && !isSmallScreen && (
+        {isSmartphonePicture && !isMobile && (
           <Image
             src="/lp/welcome-4-sp.png"
             alt="sp image"
@@ -96,7 +97,7 @@ const EffectSection: React.FC<EffectSectionProps> = ({
           >
             {title}
           </Typography>
-          {isSmallScreen && (
+          {isMobile && (
             <Box
               my={2.5}
               bgcolor="#f3f4f5"
@@ -123,7 +124,7 @@ const EffectSection: React.FC<EffectSectionProps> = ({
               />
             </Box>
           )}
-          {isSmartphonePicture && isSmallScreen && (
+          {isSmartphonePicture && isMobile && (
             <Image
               src="/lp/welcome-4-sp.png"
               alt="mp image"

--- a/src/features/routes/welcome/third-view/AppealCard.tsx
+++ b/src/features/routes/welcome/third-view/AppealCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { Box, Typography } from "@mui/material";
-import useIsMobile from "@/src/hooks/responsive/useIsMobile";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 
 export type AppealCardProps = {
   image: string;

--- a/src/features/routes/welcome/third-view/AppealCard.tsx
+++ b/src/features/routes/welcome/third-view/AppealCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
-import { Box, Typography, useMediaQuery } from "@mui/material";
-import { theme } from "@/src/utils/theme";
+import { Box, Typography } from "@mui/material";
+import useIsMobile from "@/src/hooks/responsive/useIsMobile";
 
 export type AppealCardProps = {
   image: string;
@@ -15,7 +15,7 @@ const AppealCard: React.FC<AppealCardProps> = ({
   description,
   isComingSoon = false
 }) => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
 
   return (
     <Box
@@ -53,7 +53,7 @@ const AppealCard: React.FC<AppealCardProps> = ({
         alt={"feature image"}
         width={90}
         height={90}
-        style={isSmallScreen ? { width: 70, height: 70, marginRight: 10 } : {}}
+        style={isMobile ? { width: 70, height: 70, marginRight: 10 } : {}}
       />
       <Box textAlign={{ xs: "left", sm: "center" }}>
         <Typography

--- a/src/hooks/responsive/useIsMobile.ts
+++ b/src/hooks/responsive/useIsMobile.ts
@@ -1,8 +1,6 @@
 import { useMediaQuery } from "@mui/material";
 import { theme } from "@/src/utils/theme";
 
-const useIsMobile = (): boolean => {
+export const useIsMobile = (): boolean => {
   return useMediaQuery(theme.breakpoints.down("sm"));
 };
-
-export default useIsMobile;

--- a/src/hooks/responsive/useIsMobile.ts
+++ b/src/hooks/responsive/useIsMobile.ts
@@ -1,0 +1,8 @@
+import { useMediaQuery } from "@mui/material";
+import { theme } from "@/src/utils/theme";
+
+const useIsMobile = (): boolean => {
+  return useMediaQuery(theme.breakpoints.down("sm"));
+};
+
+export default useIsMobile;


### PR DESCRIPTION
## やったこと
- hooks/responsive配下にuseIsMobile.tsを作成して以下のコードを内製化した
`useMediaQuery(theme.breakpoints.down("sm"));`
- コンポーネント側ではisMobileとして定義

## 動作確認動画(スクリーンショット)
レスポンシブによって大きくUIが変わるところ抜粋で添付
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/d5b2624b-3f4a-4168-ac8c-061a97c9629f" />
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/879ead01-91a5-4246-95c4-4df25cd64196" />

## 確認したこと(デグレチェック)
- マイブック機能のスワイパー
- デフォルトフッターはPWAでは関係ないので割愛
- AIからフィードバックをもらうところで"column-reverse"と"row"が効いてるか
- AIタイプ(ポジティブAI)のフォントサイズ
- welcomeページ(FIrstView.tsx)の1行目レスポンシブ
- welcomeページの画像と文章のレスポンシブ
- 昨日のアピール部分のレスポンシブ

## リリース時本番環境で確認すること
