### PR TITLE
投稿の公開と非公開の数をそれぞれ取得するAPIを作成

### DIFF
--- a/src/api/reflection-char-count-api.ts
+++ b/src/api/reflection-char-count-api.ts
@@ -6,6 +6,12 @@ type AllReflectionContent = {
   allContent: string;
 };
 
+type PublicPrivateCount = {
+  public: number;
+  private: number;
+};
+
+// TODO: 命名変更する
 export const reflectionCharCountAPI = {
   async getAllReflectionContent(
     username: string
@@ -15,5 +21,15 @@ export const reflectionCharCountAPI = {
       method: "GET"
     };
     return await fetchURL<AllReflectionContent, 404>(path, options);
+  },
+
+  async getPublicPrivateCount(
+    username: string
+  ): Promise<Result<PublicPrivateCount, 404>> {
+    const path = `/api/${username}/detail/public-private-reflection`;
+    const options: FetchURLOptions = {
+      method: "GET"
+    };
+    return await fetchURL<PublicPrivateCount, 404>(path, options);
   }
 };

--- a/src/app/(multi-footer)/[username]/test/page.tsx
+++ b/src/app/(multi-footer)/[username]/test/page.tsx
@@ -9,14 +9,36 @@ type PageProps = {
 };
 
 const page = async ({ params }: PageProps) => {
+  // TODO: それぞれのapiを並列処理する
   const AllContentWithHTML =
     await reflectionCharCountAPI.getAllReflectionContent(params.username);
   if (AllContentWithHTML === 404) {
     return notFound();
   }
+  const publicPrivateCount = await reflectionCharCountAPI.getPublicPrivateCount(
+    params.username
+  );
+  if (publicPrivateCount === 404) {
+    return notFound();
+  }
 
   const allPlainContent = removeHtmlTags(AllContentWithHTML.allContent);
-  return <>{allPlainContent.length}</>;
+  return (
+    <>
+      <div>
+        <span>公開</span>
+        {publicPrivateCount.public}
+      </div>
+      <div>
+        <span>非公開</span>
+        {publicPrivateCount.private}
+      </div>
+      <div>
+        <span>文字数</span>
+        {allPlainContent.length}
+      </div>
+    </>
+  );
 };
 
 export default page;

--- a/src/app/api/[username]/detail/public-private-reflection/route.ts
+++ b/src/app/api/[username]/detail/public-private-reflection/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { reflectionService } from "@/src/service/reflectionService";
+import { getUserIdByUsername } from "@/src/utils/actions/get-userId-by-username";
+import { internalServerError, notFoundError } from "@/src/utils/http-error";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { username: string } }
+) {
+  const username = params.username;
+  const userId = await getUserIdByUsername(username);
+
+  if (!userId) {
+    return notFoundError("ユーザーが見つかりません");
+  }
+
+  try {
+    const publicPrivateCount =
+      await reflectionService.getPublicPrivateCount(userId);
+
+    return NextResponse.json(publicPrivateCount);
+  } catch (error) {
+    return internalServerError("GET", "公開・非公開の振り返り数", error);
+  }
+}

--- a/src/infrastructure/repository/reflectionRepository.ts
+++ b/src/infrastructure/repository/reflectionRepository.ts
@@ -299,5 +299,17 @@ export const reflectionRepository = {
         content: true
       }
     });
+  },
+
+  async getPublicPrivateCount(userId: string) {
+    return await prisma.reflection.groupBy({
+      by: ["isPublic"],
+      where: {
+        userId
+      },
+      _count: {
+        _all: true
+      }
+    });
   }
 };

--- a/src/service/reflectionService.ts
+++ b/src/service/reflectionService.ts
@@ -341,6 +341,20 @@ export const reflectionService = {
     );
 
     return hourlyReflections;
+  },
+
+  async getPublicPrivateCount(userId: string) {
+    const reflections =
+      await reflectionRepository.getPublicPrivateCount(userId);
+
+    // MEMO: 公開と非公開の投稿数を取得
+    const publicCount = reflections.find((r) => r.isPublic)?._count._all ?? 0;
+    const privateCount = reflections.find((r) => !r.isPublic)?._count._all ?? 0;
+
+    return {
+      public: publicCount,
+      private: privateCount
+    };
   }
 };
 


### PR DESCRIPTION
## やったこと
- 投稿の公開と非公開の数をそれぞれ取得するAPIを作成
- 画面に表示する

## 動作確認動画(スクリーンショット)
<img width="1470" alt="スクリーンショット 2025-03-13 12 28 05" src="https://github.com/user-attachments/assets/3ef1c4a4-c304-49cb-b894-258cb251e0f0" />

## 確認したこと(デグレチェック)
- それぞれの数が正しいかどうか
- 公開、または非公開が0であるときは0を返すこと
