### PR TITLE
既存の並列処理でAPI叩いているページのコード量を減らす

### DIFF
--- a/src/app/(multi-footer)/settings/username/page.tsx
+++ b/src/app/(multi-footer)/settings/username/page.tsx
@@ -17,23 +17,22 @@ const page = async ({ searchParams }: { searchParams: { page?: string } }) => {
     redirect(`/${session.user.username}`);
   }
 
-  const countResult = await reflectionsTagCountAPI.getReflectionTagCountList();
-  const reflectionsResult = await reflectionAPI.getReflectionAll();
+  const [count, reflectionAll] = await Promise.all([
+    reflectionsTagCountAPI.getReflectionTagCountList(),
+    reflectionAPI.getReflectionAll()
+  ]);
 
-  if (countResult === 500 || reflectionsResult === 404) {
+  if (count === 500 || reflectionAll === 404) {
     return notFound();
   }
-
-  // MEMO: 並列データフェッチ
-  const [count, result] = await Promise.all([countResult, reflectionsResult]);
 
   return (
     <SettingUsernameModalPage
       currentUsername={session?.user.username || null}
       image={session?.user.image || ""}
-      reflections={result.reflections}
+      reflections={reflectionAll.reflections}
       currentPage={currentPage}
-      totalPage={result.totalPage}
+      totalPage={reflectionAll.totalPage}
       tagCountList={count.tagCountList}
     />
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,26 +19,22 @@ const page = async ({
 
   const session = await getServerSession(authOptions);
 
-  const countResult = await reflectionsTagCountAPI.getReflectionTagCountList();
-  const reflectionsResult = await reflectionAPI.getReflectionAll(
-    currentPage,
-    selectedTag
-  );
+  const [count, reflectionAll] = await Promise.all([
+    reflectionsTagCountAPI.getReflectionTagCountList(),
+    reflectionAPI.getReflectionAll(currentPage, selectedTag)
+  ]);
 
-  if (countResult === 500 || reflectionsResult === 404) {
+  if (count === 500 || reflectionAll === 404) {
     return notFound();
   }
-
-  // MEMO: 並列データフェッチ
-  const [count, result] = await Promise.all([countResult, reflectionsResult]);
 
   return (
     <RootPage
       currentUsername={session?.user.username || null}
       image={session?.user.image || ""}
-      reflections={result.reflections}
+      reflections={reflectionAll.reflections}
       currentPage={currentPage}
-      totalPage={result.totalPage}
+      totalPage={reflectionAll.totalPage}
       tagCountList={count.tagCountList}
     />
   );


### PR DESCRIPTION
## やったこと
- 以下のrootのリファクタリング
  - マイページ
  - rootページ
  - ユーザーネーム登録ページ

## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/cdbdabe9-d453-4147-b5a4-a35762a3c1b3

## 確認したこと(デグレチェック)
- 問題なく既存ページが見れること

## リリース時本番環境で確認すること
- ページ遷移が通常通りの速さで表示されること
