### PR TITLE
フォルダ周りのロジックをhooksに全て移行する

### DIFF
--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -2,7 +2,6 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { Box, useMediaQuery } from "@mui/material";
 import type { ReflectionsCount } from "@/src/api/reflections-count-api";
-import type { TagType } from "@/src/hooks/reflection-tag/useExtractTrueTags";
 import type { User } from "@prisma/client";
 import { type Folder } from "@/src/api/folder-api";
 import {
@@ -24,8 +23,6 @@ import { Sidebar } from "@/src/features/routes/reflection-list/sidebar";
 import { FolderInitializer } from "@/src/features/routes/reflection-list/sidebar/FolderInitializer";
 import { useFolderSelection } from "@/src/hooks/folder/useFolderSelection";
 import { usePagination } from "@/src/hooks/reflection/usePagination";
-import { tagMap } from "@/src/hooks/reflection-tag/useExtractTrueTags";
-import { useFolderStore } from "@/src/utils/store/useFolderStore";
 
 type UserReflectionListPageProps = {
   currentUsername: User["username"];
@@ -60,7 +57,6 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   const searchParams = useSearchParams();
   const isPWA = useMediaQuery("(display-mode: standalone)");
   const { handlePageChange } = usePagination();
-
   const {
     isSelectMode,
     selectedReflections,
@@ -69,33 +65,18 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
     handleSelectMode,
     handleSelect,
     handleCancelSelectMode,
-    handleAddReflectionToFolder
+    handleAddReflectionToFolder,
+    getSelectedInfo
   } = useFolderSelection(username);
 
   const isCurrentUser = currentUsername === username;
+  // NOTE: 選択されたフォルダかタグの投稿数と名前を取得
+  const selectedInfo = getSelectedInfo(tagCountList);
+
   const isModalOpen = searchParams.get("status") === "posted";
   const handleCloseModal = () => {
     router.push(`/${username}`);
   };
-
-  const foldersState = useFolderStore((state) => state.folders);
-  const selectedInfo = useFolderStore((state) => state.selectedInfo);
-  const currentFolder = foldersState.find((f) => f.folderUUID === selectedInfo);
-  const selected = (() => {
-    if (currentFolder) {
-      return {
-        name: currentFolder.name,
-        count: currentFolder.countByFolder || 0
-      };
-    }
-    if (tagMap[selectedInfo as keyof TagType]) {
-      return {
-        name: tagMap[selectedInfo as keyof TagType],
-        count: tagCountList[selectedInfo as keyof ReflectionTagCountList] || 0
-      };
-    }
-    return null;
-  })();
 
   return (
     <>
@@ -119,7 +100,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
           isCurrentUser={isCurrentUser}
         />
         <SelectionHeader
-          selectedInfo={selected}
+          selectedInfo={selectedInfo}
           isFolderSelected={isFolderSelected}
           isSelectMode={isSelectMode}
           onCancel={handleCancelSelectMode}

--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -1,13 +1,11 @@
 "use client";
-import { useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Box, useMediaQuery } from "@mui/material";
 import type { ReflectionsCount } from "@/src/api/reflections-count-api";
 import type { TagType } from "@/src/hooks/reflection-tag/useExtractTrueTags";
 import type { User } from "@prisma/client";
-import { folderAPI, type Folder } from "@/src/api/folder-api";
+import { type Folder } from "@/src/api/folder-api";
 import {
-  reflectionAPI,
   type RandomReflection,
   type Reflection,
   type ReflectionTagCountList
@@ -24,9 +22,9 @@ import UserProfileArea from "@/src/features/routes/reflection-list/profile/UserP
 import { SelectionHeader } from "@/src/features/routes/reflection-list/selection-header/SelectionHeader";
 import { Sidebar } from "@/src/features/routes/reflection-list/sidebar";
 import { FolderInitializer } from "@/src/features/routes/reflection-list/sidebar/FolderInitializer";
+import { useFolderSelection } from "@/src/hooks/folder/useFolderSelection";
 import { usePagination } from "@/src/hooks/reflection/usePagination";
 import { tagMap } from "@/src/hooks/reflection-tag/useExtractTrueTags";
-import { getReflectionWithFolderInfo } from "@/src/utils/actions/get-reflection-with-folder-info";
 import { useFolderStore } from "@/src/utils/store/useFolderStore";
 
 type UserReflectionListPageProps = {
@@ -58,70 +56,21 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
   randomReflection,
   folders
 }) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSelectMode, setIsSelectMode] = useState(false);
-  const [selectedReflections, setSelectedReflections] = useState<string[]>([]);
   const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
   const isPWA = useMediaQuery("(display-mode: standalone)");
-
   const { handlePageChange } = usePagination();
 
-  const foldersState = useFolderStore((state) => state.folders);
-  const selectedInfo = useFolderStore((state) => state.selectedInfo);
-  const setFolders = useFolderStore((state) => state.setFolders);
-  const setSelectedInfo = useFolderStore((state) => state.setSelectedInfo);
-  const handleSelectMode = async (folderUUID: string) => {
-    router.push(pathname);
-    setIsSelectMode(true);
-    setSelectedInfo(folderUUID);
-    const info = await getReflectionWithFolderInfo(username, folderUUID);
-    if (!info) return;
-    const preSelected = info.map((i) => i.reflectionCUID);
-    setSelectedReflections(preSelected);
-  };
-
-  const handleSelect = (reflectionCUID: string) => {
-    setSelectedReflections((prev) => {
-      if (prev.includes(reflectionCUID)) {
-        return prev.filter((id) => id !== reflectionCUID);
-      } else {
-        return [...prev, reflectionCUID];
-      }
-    });
-  };
-
-  const handleCancelSelectMode = () => {
-    setIsSelectMode(false);
-    setSelectedReflections([]);
-    setSelectedInfo("");
-  };
-
-  const handleAddReflectionToFolder = async () => {
-    setIsLoading(true);
-
-    await reflectionAPI.bulkUpdateFolderReflection({
-      reflectionCUID: selectedReflections,
-      folderUUID: selectedInfo,
-      username
-    });
-    const updatedFolders = await folderAPI.getFolder(username);
-    if (updatedFolders === 404) {
-      return router.refresh();
-    }
-
-    setFolders(updatedFolders);
-    setIsSelectMode(false);
-    setSelectedReflections([]);
-    setIsLoading(false);
-    router.push(`/${username}?folder=${selectedInfo}`);
-    router.refresh();
-  };
-  const isFolderSelected = foldersState.some(
-    (f) => f.folderUUID === selectedInfo
-  );
-  const disableAdd = selectedReflections.length === 0 || isLoading;
+  const {
+    isSelectMode,
+    selectedReflections,
+    isFolderSelected,
+    disableAdd,
+    handleSelectMode,
+    handleSelect,
+    handleCancelSelectMode,
+    handleAddReflectionToFolder
+  } = useFolderSelection(username);
 
   const isCurrentUser = currentUsername === username;
   const isModalOpen = searchParams.get("status") === "posted";
@@ -129,6 +78,8 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
     router.push(`/${username}`);
   };
 
+  const foldersState = useFolderStore((state) => state.folders);
+  const selectedInfo = useFolderStore((state) => state.selectedInfo);
   const currentFolder = foldersState.find((f) => f.folderUUID === selectedInfo);
   const selected = (() => {
     if (currentFolder) {

--- a/src/hooks/folder/useFolderSelection.ts
+++ b/src/hooks/folder/useFolderSelection.ts
@@ -45,7 +45,7 @@ export const useFolderSelection = (username: string) => {
       : null;
   };
 
-  // NOTE: 選択されたフォルダかタグの投稿数を取得する。
+  // NOTE: 選択されたフォルダかタグの名前と投稿数を取得する
   const getSelectedInfo = (tagCountList: ReflectionTagCountList) => {
     if (!selectedInfo) return null;
     return (

--- a/src/hooks/folder/useFolderSelection.ts
+++ b/src/hooks/folder/useFolderSelection.ts
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { folderAPI } from "@/src/api/folder-api";
+import { reflectionAPI } from "@/src/api/reflection-api";
+import { getReflectionWithFolderInfo } from "@/src/utils/actions/get-reflection-with-folder-info";
+import { useFolderStore } from "@/src/utils/store/useFolderStore";
+
+export const useFolderSelection = (username: string) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSelectMode, setIsSelectMode] = useState(false);
+  const [selectedReflections, setSelectedReflections] = useState<string[]>([]);
+
+  const router = useRouter();
+  const {
+    folders: foldersState,
+    selectedInfo,
+    setFolders,
+    setSelectedInfo
+  } = useFolderStore();
+
+  const isFolderSelected = foldersState.some(
+    (f) => f.folderUUID === selectedInfo
+  );
+  const disableAdd = selectedReflections.length === 0 || isLoading;
+
+  const handleSelectMode = async (folderUUID: string) => {
+    router.push(`/${username}`);
+    setIsSelectMode(true);
+    setSelectedInfo(folderUUID);
+    const info = await getReflectionWithFolderInfo(username, folderUUID);
+    if (!info) return;
+    const preSelected = info.map((i) => i.reflectionCUID);
+    setSelectedReflections(preSelected);
+  };
+
+  const handleSelect = (reflectionCUID: string) => {
+    setSelectedReflections((prev) => {
+      if (prev.includes(reflectionCUID)) {
+        return prev.filter((id) => id !== reflectionCUID);
+      }
+      return [...prev, reflectionCUID];
+    });
+  };
+
+  const handleCancelSelectMode = () => {
+    setIsSelectMode(false);
+    setSelectedReflections([]);
+    setSelectedInfo("");
+  };
+
+  const handleAddReflectionToFolder = async () => {
+    setIsLoading(true);
+    await reflectionAPI.bulkUpdateFolderReflection({
+      reflectionCUID: selectedReflections,
+      folderUUID: selectedInfo,
+      username
+    });
+    const updatedFolders = await folderAPI.getFolder(username);
+    if (updatedFolders === 404) {
+      return router.refresh();
+    }
+
+    setFolders(updatedFolders);
+    setIsSelectMode(false);
+    setSelectedReflections([]);
+    setIsLoading(false);
+    router.push(`/${username}?folder=${selectedInfo}`);
+    router.refresh();
+  };
+
+  return {
+    isLoading,
+    isSelectMode,
+    selectedReflections,
+    selectedInfo,
+    isFolderSelected,
+    disableAdd,
+    handleSelectMode,
+    handleSelect,
+    handleCancelSelectMode,
+    handleAddReflectionToFolder
+  };
+};

--- a/src/hooks/folder/useFolderSelection.ts
+++ b/src/hooks/folder/useFolderSelection.ts
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import type { ReflectionTagCountList } from "@/src/api/reflection-api";
+import { tagMap, type TagType } from "../reflection-tag/useExtractTrueTags";
 import { folderAPI } from "@/src/api/folder-api";
 import { reflectionAPI } from "@/src/api/reflection-api";
 import { getReflectionWithFolderInfo } from "@/src/utils/actions/get-reflection-with-folder-info";
@@ -22,6 +24,35 @@ export const useFolderSelection = (username: string) => {
     (f) => f.folderUUID === selectedInfo
   );
   const disableAdd = selectedReflections.length === 0 || isLoading;
+
+  const getFolderSelectionInfo = (folderUUID: string) => {
+    const folder = foldersState.find((f) => f.folderUUID === folderUUID);
+    return folder
+      ? { name: folder.name, count: folder.countByFolder || 0 }
+      : null;
+  };
+
+  const getTagSelectionInfo = (
+    tagId: string,
+    tagCountList: ReflectionTagCountList
+  ) => {
+    const tagName = tagMap[tagId as keyof TagType];
+    return tagName
+      ? {
+          name: tagName,
+          count: tagCountList[tagId as keyof ReflectionTagCountList] || 0
+        }
+      : null;
+  };
+
+  // NOTE: 選択されたフォルダかタグの投稿数を取得する。
+  const getSelectedInfo = (tagCountList: ReflectionTagCountList) => {
+    if (!selectedInfo) return null;
+    return (
+      getFolderSelectionInfo(selectedInfo) ||
+      getTagSelectionInfo(selectedInfo, tagCountList)
+    );
+  };
 
   const handleSelectMode = async (folderUUID: string) => {
     router.push(`/${username}`);
@@ -69,7 +100,6 @@ export const useFolderSelection = (username: string) => {
   };
 
   return {
-    isLoading,
     isSelectMode,
     selectedReflections,
     selectedInfo,
@@ -78,6 +108,9 @@ export const useFolderSelection = (username: string) => {
     handleSelectMode,
     handleSelect,
     handleCancelSelectMode,
-    handleAddReflectionToFolder
+    handleAddReflectionToFolder,
+    getFolderSelectionInfo,
+    getTagSelectionInfo,
+    getSelectedInfo
   };
 };


### PR DESCRIPTION
## やったこと
- /usernameの肥大化を防ぐ

## 動作確認動画(スクリーンショット)
↓ローカルのせいで動作が遅いです

https://github.com/user-attachments/assets/663857fb-168a-4288-8430-7e619e507256

## 確認したこと(デグレチェック)
- フォルダを作成できること
- フォルダに投稿を追加できること
- フォルダの名前を編集できること
- フォルダを削除できること

## リリース時本番環境で確認すること
- フォルダを作成できること
- フォルダに投稿を追加できること
- フォルダの名前を編集できること
- フォルダを削除できること
