### PR TITLE
useMediaQuery(theme.breakpoints.down("md"))を撲滅させる

### DIFF
--- a/src/features/common/post-form/ReflectionPostForm.tsx
+++ b/src/features/common/post-form/ReflectionPostForm.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { Controller } from "react-hook-form";
-import { Box, Stack, useMediaQuery } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import type { MarkdownEditorRef } from "../../routes/post/markdown-editor";
 import type { Folder } from "@/src/api/folder-api";
 import type { Control, FieldErrors } from "react-hook-form";
@@ -24,7 +24,7 @@ import {
 import { Button } from "@/src/components/button";
 import { CustomInput } from "@/src/components/input";
 import { useExtractTrueTags } from "@/src/hooks/reflection-tag/useExtractTrueTags";
-import { theme } from "@/src/utils/theme";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 
 type FormValues = {
   title: string;
@@ -91,7 +91,7 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
 }) => {
   const [isComposing, setIsComposing] = useState(false);
   const editorRef = useRef<MarkdownEditorRef>(null);
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isMobile = useIsMobile();
 
   const activeTags = useExtractTrueTags({
     isDailyReflection,
@@ -176,7 +176,7 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
           >
             <Box display={"flex"}>
               <MarkdownSupportPopupAreaContainer />
-              {!isSmallScreen && (
+              {!isMobile && (
                 <BGMSettingPopupAreaContainer
                   currentTrack={currentTrack ?? ""}
                   playTrack={playTrack}
@@ -211,7 +211,7 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
               </Button>
             </Box>
           </Box>
-          {isSmallScreen && (
+          {isMobile && (
             <Box
               px={1.5}
               py={0.8}
@@ -270,7 +270,7 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
                 </Box>
               )}
             />
-            {!isSmallScreen && (
+            {!isMobile && (
               <Box display={"flex"} gap={2} sx={{ color: "black !important" }}>
                 <SelectTagPopupContainer
                   value={activeTags}

--- a/src/features/routes/reflection-all-list/header/ReflectionAllHeader.tsx
+++ b/src/features/routes/reflection-all-list/header/ReflectionAllHeader.tsx
@@ -1,7 +1,7 @@
-import { Box, Typography, useMediaQuery } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import type { User } from "@prisma/client";
 import { ToOtherPageButton } from "../button";
-import { theme } from "@/src/utils/theme";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 
 type ReflectionAllHeaderProps = {
   currentUsername: User["username"];
@@ -12,7 +12,7 @@ export const ReflectionAllHeader: React.FC<ReflectionAllHeaderProps> = ({
   currentUsername,
   image
 }) => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isMobile = useIsMobile();
   return (
     <Box
       display={"flex"}
@@ -25,7 +25,7 @@ export const ReflectionAllHeader: React.FC<ReflectionAllHeaderProps> = ({
       <Typography component={"h1"} fontSize={17} letterSpacing={1}>
         みんなの振り返り(公開のみ)
       </Typography>
-      {!isSmallScreen && (
+      {!isMobile && (
         <ToOtherPageButton currentUsername={currentUsername} image={image} />
       )}
     </Box>

--- a/src/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
+++ b/src/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useRef } from "react";
-import { Box, Typography, useMediaQuery } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import type { ReflectionPerDate } from "@/src/api/reflections-count-api";
 import type { ReactCalendarHeatmapValue } from "react-calendar-heatmap";
 import "react-calendar-heatmap/dist/styles.css";
@@ -7,6 +7,7 @@ import Calendar from "./Calendar";
 import "./calendar.css";
 import ToggleJapaneseLabel from "./ToggleJapaneseLabel";
 import { useToggleJapaneseLabels } from "@/src/hooks/calendar/useToggleJapaneseLabels";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
 
 type CalendarAreaProps = {
@@ -30,12 +31,12 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
   tooltipDataAttrs,
   totalReflections
 }) => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isMobile = useIsMobile();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // MEMO: 画面幅が小さい場合、カレンダーのスクロールを右端に移動する。useEffectでエラー回避
   useEffect(() => {
-    if (isSmallScreen && scrollContainerRef.current) {
+    if (isMobile && scrollContainerRef.current) {
       requestAnimationFrame(() => {
         if (scrollContainerRef.current) {
           scrollContainerRef.current.scrollLeft =
@@ -43,19 +44,17 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
         }
       });
     }
-  }, [isSmallScreen]);
+  }, [isMobile]);
 
   const { calendarRef, isJapanese, handleToggleLabels } =
     useToggleJapaneseLabels();
 
   return (
     <Box mt={5} mb={3} mx={3}>
-      {isSmallScreen && (
-        <ToggleJapaneseLabel onToggleLabel={handleToggleLabels} />
-      )}
+      {isMobile && <ToggleJapaneseLabel onToggleLabel={handleToggleLabels} />}
       <Box
         display={"flex"}
-        justifyContent={{ md: "space-between" }}
+        justifyContent={{ sm: "space-between" }}
         alignItems={"center"}
         mb={0.5}
       >
@@ -64,7 +63,7 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
             ? `直近1年間で ${totalReflections} 回振り返りをしています`
             : `${totalReflections} reflections in the last year`}
         </Typography>
-        {!isSmallScreen && (
+        {!isMobile && (
           <ToggleJapaneseLabel onToggleLabel={handleToggleLabels} />
         )}
       </Box>
@@ -78,10 +77,10 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
         <Box
           ref={scrollContainerRef}
           sx={{
-            overflowX: isSmallScreen ? "auto" : "visible"
+            overflowX: isMobile ? "auto" : "visible"
           }}
         >
-          <Box minWidth={isSmallScreen ? "780px" : "100%"}>
+          <Box minWidth={isMobile ? "780px" : "100%"}>
             <Calendar
               startDate={startDate}
               endDate={endDate}

--- a/src/features/routes/reflection-list/profile/calendar/ToggleJapaneseLabel.tsx
+++ b/src/features/routes/reflection-list/profile/calendar/ToggleJapaneseLabel.tsx
@@ -1,6 +1,5 @@
-import { Box, Typography, useMediaQuery } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { IOSSwitch } from "@/src/components/switch";
-import { theme } from "@/src/utils/theme";
 
 type ToggleJapaneseLabelProps = {
   onToggleLabel: () => void;
@@ -9,16 +8,8 @@ type ToggleJapaneseLabelProps = {
 const ToggleJapaneseLabel: React.FC<ToggleJapaneseLabelProps> = ({
   onToggleLabel
 }) => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
-
   return (
-    <Box
-      display={"flex"}
-      alignItems={"center"}
-      mx={{ xs: 1, md: 0.5 }}
-      // MEMO: md以下時にmb適用
-      mb={isSmallScreen ? 1 : undefined}
-    >
+    <Box display={"flex"} alignItems={"center"} mx={{ xs: 1, md: 0.5 }}>
       <Typography fontSize={11} mr={0.8}>
         日本語表示
       </Typography>


### PR DESCRIPTION
## やったこと
- useMediaQuery(theme.breakpoints.down("md"))をuseIsMobileに置き換える

## 確認したこと(デグレチェック)
影響範囲がある以下のページを確認した
- /post
- /root
- /{username}

## リリース時本番環境で確認すること
影響範囲がある以下のページを確認した
- /post
- /root
- /{username}
