### PR TITLE
ログインしていないユーザーはログインボタンがヘッダーに表示されるようにする

### DIFF
--- a/src/app/(multi-footer)/[username]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/page.client.tsx
@@ -2,7 +2,6 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { Box, useMediaQuery } from "@mui/material";
 import type { ReflectionsCount } from "@/src/api/reflections-count-api";
-import type { User } from "@prisma/client";
 import { type Folder } from "@/src/api/folder-api";
 import {
   type RandomReflection,
@@ -26,8 +25,8 @@ import { useFolderSelection } from "@/src/hooks/folder/useFolderSelection";
 import { usePagination } from "@/src/hooks/reflection/usePagination";
 
 type UserReflectionListPageProps = {
-  currentUsername: User["username"];
-  currentUserImage: string;
+  currentUsername: string | null;
+  currentUserImage: string | null;
   userImage: string;
   username: string;
   bio: string;
@@ -95,7 +94,7 @@ const UserReflectionListPage: React.FC<UserReflectionListPageProps> = ({
           </>
         )}
         <UserMenuHeaderContainer
-          userImage={currentUserImage || ""}
+          userImage={currentUserImage}
           username={currentUsername}
         />
         <UserProfileArea

--- a/src/app/(multi-footer)/[username]/page.tsx
+++ b/src/app/(multi-footer)/[username]/page.tsx
@@ -74,7 +74,7 @@ const page = async ({
   return (
     <UserReflectionListPage
       currentUsername={session?.username || null}
-      currentUserImage={session?.image ?? ""}
+      currentUserImage={session?.image || null}
       userImage={reflectionsWithUser.userImage}
       username={username}
       bio={reflectionsWithUser.bio}

--- a/src/app/(multi-footer)/[username]/report/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/report/page.client.tsx
@@ -3,6 +3,8 @@ import Image from "next/image";
 import { UserMenuHeaderContainer } from "@/src/features/common/user-menu";
 
 type UserReportPageProps = {
+  currentUsername: string | null;
+  currentImage: string | null;
   image: string;
   username: string;
   isReportOpen: boolean;
@@ -12,6 +14,8 @@ type UserReportPageProps = {
 };
 
 export const UserReportPage: React.FC<UserReportPageProps> = ({
+  currentUsername,
+  currentImage,
   image,
   isReportOpen,
   publicCount,
@@ -21,7 +25,10 @@ export const UserReportPage: React.FC<UserReportPageProps> = ({
 }) => {
   return (
     <>
-      <UserMenuHeaderContainer userImage={image} username={username} />
+      <UserMenuHeaderContainer
+        userImage={currentImage}
+        username={currentUsername}
+      />
       <div>
         <span>公開</span>
         {publicCount}

--- a/src/app/(multi-footer)/[username]/report/page.tsx
+++ b/src/app/(multi-footer)/[username]/report/page.tsx
@@ -1,10 +1,8 @@
 import { notFound } from "next/navigation";
-// import { getServerSession } from "next-auth";
 import { UserReportPage } from "./page.client";
 import { userReportAPI } from "@/src/api/user-report-api";
-// import authOptions from "@/src/app/api/auth/[...nextauth]/options";
+import { getUserSession } from "@/src/utils/get-user-session";
 import { removeHtmlTags } from "@/src/utils/remove-html-tags";
-
 type PageProps = {
   params: {
     username: string;
@@ -12,7 +10,7 @@ type PageProps = {
 };
 
 const page = async ({ params }: PageProps) => {
-  // const session = await getServerSession(authOptions);
+  const session = await getUserSession();
   const [reflectionContent, reflectionCounts, userProfile] = await Promise.all([
     userReportAPI.getAllReflectionContent(params.username),
     userReportAPI.getPublicPrivateCount(params.username),
@@ -35,6 +33,8 @@ const page = async ({ params }: PageProps) => {
   const allPlainContent = removeHtmlTags(reflectionContent.allContent);
   return (
     <UserReportPage
+      currentUsername={session?.username || null}
+      currentImage={session?.image || null}
       image={userProfile.image}
       username={params.username}
       isReportOpen={userProfile.isReportOpen}

--- a/src/app/(multi-footer)/settings/username/page.client.tsx
+++ b/src/app/(multi-footer)/settings/username/page.client.tsx
@@ -3,13 +3,12 @@ import type {
   ReflectionTagCountList,
   ReflectionWithUser
 } from "@/src/api/reflection-api";
-import type { User } from "@prisma/client";
 import RootPage from "@/src/app/page.client";
 import SettingUsernameModalContainer from "@/src/features/routes/setting-username/SettingUsernameModalContainer";
 
 type SettingUsernameModalPageProps = {
-  currentUsername: User["username"];
-  image: string;
+  username: string | null;
+  image: string | null;
   reflections: ReflectionWithUser[];
   currentPage: number;
   totalPage: number;
@@ -17,7 +16,7 @@ type SettingUsernameModalPageProps = {
 };
 
 const SettingUsernameModalPage: React.FC<SettingUsernameModalPageProps> = ({
-  currentUsername,
+  username,
   image,
   reflections,
   currentPage,
@@ -29,7 +28,7 @@ const SettingUsernameModalPage: React.FC<SettingUsernameModalPageProps> = ({
       <SettingUsernameModalContainer open />
       {/* // NOTE: RootPageはただのモーダルの背景として置いている */}
       <RootPage
-        currentUsername={currentUsername}
+        username={username}
         image={image}
         reflections={reflections}
         currentPage={currentPage}

--- a/src/app/(multi-footer)/settings/username/page.tsx
+++ b/src/app/(multi-footer)/settings/username/page.tsx
@@ -27,8 +27,8 @@ const page = async ({ searchParams }: { searchParams: { page?: string } }) => {
 
   return (
     <SettingUsernameModalPage
-      currentUsername={session?.username || null}
-      image={session?.image || ""}
+      username={session?.username || null}
+      image={session?.image || null}
       reflections={reflectionAll.reflections}
       currentPage={currentPage}
       totalPage={reflectionAll.totalPage}

--- a/src/app/page.client.tsx
+++ b/src/app/page.client.tsx
@@ -4,7 +4,6 @@ import type {
   ReflectionTagCountList,
   ReflectionWithUser
 } from "../api/reflection-api";
-import type { User } from "@prisma/client";
 import { PostNavigationButton } from "../components/button";
 import { Footer } from "../components/footer";
 import { ArrowPagination, NumberedPagination } from "../components/pagination";
@@ -17,8 +16,8 @@ import { tagMap } from "../hooks/reflection-tag/useExtractTrueTags";
 import { useTagHandler } from "../hooks/reflection-tag/useTagHandler";
 
 type RootPageProps = {
-  currentUsername: User["username"];
-  image: string;
+  username: string | null;
+  image: string | null;
   reflections: ReflectionWithUser[];
   currentPage: number;
   totalPage: number;
@@ -26,7 +25,7 @@ type RootPageProps = {
 };
 
 const RootPage: React.FC<RootPageProps> = ({
-  currentUsername,
+  username,
   image,
   reflections,
   currentPage,
@@ -47,7 +46,7 @@ const RootPage: React.FC<RootPageProps> = ({
   return (
     <>
       <Container maxWidth="md" sx={{ mt: { xs: 8, sm: 11 }, mb: 6 }}>
-        <UserMenuHeaderContainer userImage={image} username={currentUsername} />
+        <UserMenuHeaderContainer userImage={image} username={username} />
         <ReflectionAllHeader />
         <SearchBar
           tags={Object.values(tagMap)}
@@ -63,7 +62,7 @@ const RootPage: React.FC<RootPageProps> = ({
           onChange={handlePageChange}
         />
         <ReflectionAllCardListArea
-          currentUsername={currentUsername}
+          currentUsername={username}
           reflections={reflections}
         />
         <NumberedPagination
@@ -72,7 +71,7 @@ const RootPage: React.FC<RootPageProps> = ({
           onChange={handlePageChange}
         />
       </Container>
-      {currentUsername && !isPWA && (
+      {username && !isPWA && (
         <PostNavigationButton
           sx={{
             position: "fixed",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,8 +28,8 @@ const page = async ({
 
   return (
     <RootPage
-      currentUsername={session?.username || null}
-      image={session?.image || ""}
+      username={session?.username || null}
+      image={session?.image || null}
       reflections={reflectionAll.reflections}
       currentPage={currentPage}
       totalPage={reflectionAll.totalPage}

--- a/src/features/common/user-menu/LoginButtonHeader.tsx
+++ b/src/features/common/user-menu/LoginButtonHeader.tsx
@@ -1,0 +1,34 @@
+import LoginIcon from "@mui/icons-material/Login";
+import { Box, IconButton } from "@mui/material";
+import { theme } from "@/src/utils/theme";
+
+export const LoginButtonHeader = () => {
+  return (
+    <Box
+      component={"header"}
+      display={"flex"}
+      alignItems={"center"}
+      justifyContent={"space-between"}
+      gap={1.5}
+      position={"absolute"}
+      top={27}
+      right={27}
+    >
+      <IconButton href={`/login`} sx={button}>
+        <LoginIcon sx={{ mr: 0.5, color: theme.palette.grey[600] }} />
+        ログインする
+      </IconButton>
+    </Box>
+  );
+};
+
+// TODO: 内製化したい
+const button = {
+  color: "black",
+  fontSize: 14,
+  p: "6px 12px",
+  letterSpacing: 0.8,
+  borderRadius: 2,
+  border: "1px solid #DCDFE3",
+  backgroundColor: "white"
+};

--- a/src/features/common/user-menu/UserMenuHeaderContainer.tsx
+++ b/src/features/common/user-menu/UserMenuHeaderContainer.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import type { User } from "@prisma/client";
+import { LoginButtonHeader } from "./LoginButtonHeader";
 import { UserMenuHeader } from "./UserMenuHeader";
 
 type UserMenuHeaderContainerProps = {
-  username: User["username"];
-  userImage: string;
+  username: string | null;
+  userImage: string | null;
 };
 
 export const UserMenuHeaderContainer: React.FC<
@@ -19,6 +19,10 @@ export const UserMenuHeaderContainer: React.FC<
   const handleClosePopup = () => {
     setAnchorEl(null);
   };
+
+  if (!username || !userImage) {
+    return <LoginButtonHeader />;
+  }
 
   return (
     <UserMenuHeader

--- a/src/features/routes/login/AuthButton.tsx
+++ b/src/features/routes/login/AuthButton.tsx
@@ -1,11 +1,5 @@
-import type {
-  ButtonProps,
-  SxProps} from "@mui/material";
-import {
-  Box,
-  Button as MuiButton,
-  Typography
-} from "@mui/material";
+import type { ButtonProps, SxProps } from "@mui/material";
+import { Box, Button as MuiButton, Typography } from "@mui/material";
 import type { IconType } from "react-icons";
 
 type AuthButtonProps = {


### PR DESCRIPTION
## やったこと
- ログインしていないときのヘッダーの表示
  - ログインするボタンを設置

## 動作確認動画(スクリーンショット)
https://github.com/user-attachments/assets/0aa4d40b-b1f5-40a2-a02c-34f68c915cb8

## 確認したこと(デグレチェック)
- ログインしていない時はログインするボタンのみ表示されていること
- ログインしている時は投稿するボタンとアイコンが表示されていること
