### PR TITLE
レポート画面にいくリンクを実装

### DIFF
--- a/src/features/routes/reflection-list/profile/UserProfileArea.tsx
+++ b/src/features/routes/reflection-list/profile/UserProfileArea.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic";
 import type { ReflectionsCount } from "@/src/api/reflections-count-api";
 import { UserInformationHeader } from "./header";
+import ToReportPageLink from "./to-report-link/ToReportPageLink";
 import { LinearLoading } from "@/src/components/loading";
 
 const CalendarAreaFetcher = dynamic(
@@ -38,6 +39,7 @@ const UserProfileArea: React.FC<UserProfileAreaProps> = ({
         isCurrentUser={isCurrentUser}
       />
       <CalendarAreaFetcher reflectionCount={reflectionCount} />
+      <ToReportPageLink username={username} />
     </>
   );
 };

--- a/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
+++ b/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Link from "next/link";
+import { Box } from "@mui/material";
+
+type ToReportPageLinkProps = {
+  username: string;
+};
+const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
+  return (
+    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+      <Link
+        href={`${username}/report`}
+        style={{
+          color: "#535353",
+          display: "inline-flex",
+          alignItems: "center",
+          marginRight: 28,
+          textDecoration: "none",
+          borderBottom: "0.5px solid #535353",
+          paddingBottom: 1,
+          marginTop: -14,
+          lineHeight: 0.8
+        }}
+      >
+        {username}のレポートを見る
+        <span style={{ paddingBottom: 4 }}>→</span>
+      </Link>
+    </Box>
+  );
+};
+
+export default ToReportPageLink;

--- a/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
+++ b/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
@@ -19,6 +19,7 @@ const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
           textDecoration: "none",
           borderBottom: "0.5px solid #535353",
           paddingBottom: 1,
+          // TODO: CalenderAreaの余白関係のリファクタと一緒にmarginの大きい値を削除する
           marginTop: -14,
           fontSize: theme.typography.fontSize,
           letterSpacing: 0.8

--- a/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
+++ b/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
@@ -24,7 +24,11 @@ const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
         }}
       >
         {username}のレポートを見る
-        <Typography component={"span"} style={{ paddingBottom: 4 }}>
+        <Typography
+          component={"span"}
+          style={{ paddingBottom: 4 }}
+          lineHeight={1.1}
+        >
           →
         </Typography>
       </Link>

--- a/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
+++ b/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
@@ -19,7 +19,9 @@ const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
           textDecoration: "none",
           borderBottom: "0.5px solid #535353",
           paddingBottom: 1,
-          marginTop: -14
+          marginTop: -14,
+          fontSize: theme.typography.fontSize,
+          letterSpacing: 0.8
         }}
       >
         {username}のレポートを見る

--- a/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
+++ b/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
@@ -17,7 +17,7 @@ const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
           alignItems: "center",
           marginRight: 28,
           textDecoration: "none",
-          borderBottom: "0.5px solid #535353",
+          borderBottom: `0.5px solid ${theme.palette.grey[600]}`,
           paddingBottom: 1,
           // TODO: CalenderAreaの余白関係のリファクタと一緒にmarginの大きい値を削除する
           marginTop: -14,
@@ -26,11 +26,7 @@ const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
         }}
       >
         {username}のレポートを見る
-        <Typography
-          component={"span"}
-          style={{ paddingBottom: 4 }}
-          lineHeight={1.1}
-        >
+        <Typography component={"span"} pb={0.5} lineHeight={1.1}>
           →
         </Typography>
       </Link>

--- a/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
+++ b/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
@@ -19,8 +19,7 @@ const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
           textDecoration: "none",
           borderBottom: "0.5px solid #535353",
           paddingBottom: 1,
-          marginTop: -14,
-          lineHeight: 0.8
+          marginTop: -14
         }}
       >
         {username}のレポートを見る

--- a/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
+++ b/src/features/routes/reflection-list/profile/to-report-link/ToReportPageLink.tsx
@@ -1,17 +1,18 @@
 import React from "react";
 import Link from "next/link";
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import { theme } from "@/src/utils/theme";
 
 type ToReportPageLinkProps = {
   username: string;
 };
 const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
   return (
-    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+    <Box display={"flex"} justifyContent={"flex-end"}>
       <Link
         href={`${username}/report`}
         style={{
-          color: "#535353",
+          color: theme.palette.grey[600],
           display: "inline-flex",
           alignItems: "center",
           marginRight: 28,
@@ -23,7 +24,9 @@ const ToReportPageLink: React.FC<ToReportPageLinkProps> = ({ username }) => {
         }}
       >
         {username}のレポートを見る
-        <span style={{ paddingBottom: 4 }}>→</span>
+        <Typography component={"span"} style={{ paddingBottom: 4 }}>
+          →
+        </Typography>
       </Link>
     </Box>
   );


### PR DESCRIPTION
## やったこと
- レポート画面にいくリンクを実装した
- linkに矢印（→）をそのまま書くと表示が汚くなるのでborderbottomを用いて実装した
## 動作確認動画(スクリーンショット)

### 修正前

https://github.com/user-attachments/assets/48d978ad-11b5-4a5b-a89e-cb3bec8942e5




### 修正後
https://github.com/user-attachments/assets/9091697a-3fdc-4b2d-9a58-c766aadba88e



## 確認したこと(デグレチェック)
リンクを押すとレポートページに飛ぶ
## リリース時本番環境で確認すること
