### PR TITLE
タグ別投稿割合の円グラフを作成した

### DIFF
--- a/src/app/(multi-footer)/[username]/report/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/report/page.client.tsx
@@ -6,6 +6,7 @@ import { UserMenuHeaderContainer } from "@/src/features/common/user-menu";
 import { BarChartArea } from "@/src/features/routes/report/BarChartArea";
 import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
 import { theme } from "@/src/utils/theme";
+import TagPieChartArea from "@/src/features/routes/report/TagPieChartArea";
 
 type UserReportPageProps = {
   currentUsername: string | null;
@@ -73,14 +74,7 @@ export const UserReportPage: React.FC<UserReportPageProps> = ({
             marginBottom: 4
           }}
         />
-        <p>タグカウント</p>
-        <div>
-          {Object.entries(tagCountList).map(([tagName, count]) => (
-            <div key={tagName}>
-              {tagName}: {count}件
-            </div>
-          ))}
-        </div>
+        <TagPieChartArea tagCountList={tagCountList} />
       </div>
     </>
   );

--- a/src/features/routes/report/TagPieChartArea.tsx
+++ b/src/features/routes/report/TagPieChartArea.tsx
@@ -1,0 +1,111 @@
+import { ReflectionTagCountList } from "@/src/api/reflection-api";
+import { useIsMobile } from "@/src/hooks/responsive/useIsMobile";
+import { Box, Typography } from "@mui/material";
+import { pieArcLabelClasses, PieChart } from "@mui/x-charts";
+import Image from "next/image";
+
+type TagPieChartAreaProps = {
+  tagCountList: ReflectionTagCountList;
+};
+
+const TagPieChartArea: React.FC<TagPieChartAreaProps> = ({ tagCountList }) => {
+  const isMobile = useIsMobile();
+
+  const pieData = [
+    {
+      value: tagCountList.isDailyReflection,
+      label: "振り返り",
+      color: "#397D05"
+    },
+    {
+      value: tagCountList.isLearning,
+      label: "学び",
+      color: "#4A9C0A"
+    },
+    {
+      value: tagCountList.isAwareness,
+      label: "気づき",
+      color: "#59C757"
+    },
+    {
+      value: tagCountList.isMonologue,
+      label: "ひとりごと",
+      color: "#6BDE6F"
+    },
+    {
+      value: tagCountList.isInputLog,
+      label: "インプットの記録",
+      color: "#98EF85"
+    }
+  ];
+
+  //MEMO: 投稿数が0のタグを省く
+  const filteredPieData = pieData.filter((item) => item.value !== 0);
+
+  // MEMO: タグが付けられている投稿がひとつもないかどうかを判定するbool値
+  const hasNoTagPost = filteredPieData.length === 0;
+
+  return (
+    <>
+      <Typography>タグ別の投稿割合</Typography>
+      {hasNoTagPost ? (
+        <Box
+          display={"flex"}
+          justifyContent={"center"}
+          alignItems={"center"}
+          flexDirection={"column"}
+          my={10}
+          pb={5}
+        >
+          <Image
+            src={"/not-found/no-post.png"}
+            alt={"投稿"}
+            width={200}
+            height={200}
+          />
+          <Typography>タグが付けられている投稿がありません</Typography>
+        </Box>
+      ) : (
+        <Box display={"flex"} justifyContent={"center"}>
+          <PieChart
+            height={isMobile ? 200 : 300}
+            width={600}
+            series={[
+              {
+                innerRadius: 60,
+                outerRadius: 110,
+                data: filteredPieData,
+                arcLabel: (item) => {
+                  const total = filteredPieData.reduce(
+                    (sum, i) => sum + i.value,
+                    0
+                  );
+                  const percent = ((item.value / total) * 100).toFixed(1);
+                  return `${percent}%`;
+                }
+              }
+            ]}
+            sx={{
+              [`& .${pieArcLabelClasses.root}`]: {
+                fill: "#ffffff",
+                fontSize: 11
+              }
+            }}
+            legend={{
+              direction: "column",
+              position: {
+                vertical: "middle",
+                horizontal: "right"
+              },
+              padding: 0,
+              itemMarkWidth: 12,
+              itemMarkHeight: 12
+            }}
+          />
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default TagPieChartArea;


### PR DESCRIPTION
## やったこと
- タグ別投稿割合の円グラフを作成した
## 動作確認動画(スクリーンショット)
<img width="1470" alt="スクリーンショット 2025-03-25 17 00 43" src="https://github.com/user-attachments/assets/2ba8bd1d-c7f2-4239-962c-4edc9f5b8bcf" />
<img width="1470" alt="スクリーンショット 2025-03-25 16 15 22" src="https://github.com/user-attachments/assets/c1d78481-2f71-49fb-b94d-72044f8a38fe" />

## 確認したこと(デグレチェック)
- タグ付けした投稿がない人には「タグづけされている投稿がありません」と表示されること

## リリース時本番環境で確認すること

## 別ブランチでやること
- apiを修正し、タグ別の投稿数のみ持ってくるAPIを叩く