### PR TITLE
タグ別投稿割合のAPIに置き換える

### DIFF
--- a/src/api/user-report-api.ts
+++ b/src/api/user-report-api.ts
@@ -1,3 +1,4 @@
+import type { ReflectionTagCountList } from "./reflection-api";
 import type { FetchURLOptions } from "../utils/fetchURL";
 import type { Result } from "../utils/types/result";
 import { fetchURL } from "../utils/fetchURL";
@@ -57,5 +58,15 @@ export const userReportAPI = {
       method: "GET"
     };
     return await fetchURL<HourlyPostCount, 404>(path, options);
+  },
+
+  async getTagCount(
+    username: string
+  ): Promise<Result<ReflectionTagCountList, 404>> {
+    const path = `/api/${username}/report/tag-count`;
+    const options: FetchURLOptions = {
+      method: "GET"
+    };
+    return await fetchURL<ReflectionTagCountList, 404>(path, options);
   }
 };

--- a/src/app/(multi-footer)/[username]/report/page.tsx
+++ b/src/app/(multi-footer)/[username]/report/page.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { UserReportPage } from "./page.client";
-import { reflectionAPI } from "@/src/api/reflection-api";
 import { userReportAPI } from "@/src/api/user-report-api";
-import { getHeaders } from "@/src/utils/get-headers";
 import { getUserSession } from "@/src/utils/get-user-session";
 import { meta } from "@/src/utils/metadata";
 import { removeHtmlTags } from "@/src/utils/remove-html-tags";
@@ -23,35 +21,36 @@ type PageProps = {
 
 const page = async ({ params }: PageProps) => {
   const session = await getUserSession();
-  const headers = getHeaders();
   const [
     reflectionContent,
     reflectionCounts,
     userProfile,
-    reflectionsWithUser,
-    hourlyPostCount
+    hourlyPostCount,
+    tagCountList
   ] = await Promise.all([
     userReportAPI.getAllReflectionContent(params.username),
     userReportAPI.getPublicPrivateCount(params.username),
     userReportAPI.getUserProfile(params.username),
-    reflectionAPI.getReflectionsByUsername(headers, params.username),
-    userReportAPI.getHourlyPostCount(params.username)
+    userReportAPI.getHourlyPostCount(params.username),
+    userReportAPI.getTagCount(params.username)
   ]);
 
   if (
     reflectionContent === 404 ||
     reflectionCounts === 404 ||
     userProfile === 404 ||
-    reflectionsWithUser === 404 ||
-    hourlyPostCount === 404
+    hourlyPostCount === 404 ||
+    tagCountList === 404
   ) {
     return notFound();
   }
+
   // TODO: レポートが非公開かつ、閲覧者が本人でない場合は404を返す404ページを返す。開発中は表示しておくため、リリース時にはコメントアウトを解除する
   // NOTE: 一時的に公開非公開試したい人はコメントアウトを解除してください
   // if (!userProfile.isReportOpen && session?.user.username !== params.username) {
   //   return notFound();
   // }
+
   const allPlainContent = removeHtmlTags(reflectionContent.allContent);
   return (
     <UserReportPage
@@ -63,7 +62,7 @@ const page = async ({ params }: PageProps) => {
       publicCount={reflectionCounts.public}
       privateCount={reflectionCounts.private}
       contentLength={allPlainContent.length}
-      tagCountList={reflectionsWithUser.tagCountList}
+      tagCountList={tagCountList}
       hourlyPostCount={hourlyPostCount.reflectionsDateGroup}
     />
   );

--- a/src/app/api/[username]/report/tag-count/route.ts
+++ b/src/app/api/[username]/report/tag-count/route.ts
@@ -1,0 +1,67 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { reflectionRepository } from "@/src/infrastructure/repository/reflectionRepository";
+import { getUserIdByUsername } from "@/src/utils/actions/get-userId-by-username";
+import { internalServerError, notFoundError } from "@/src/utils/http-error";
+
+export async function GET(
+  _: NextRequest,
+  { params }: { params: { username: string } }
+) {
+  const username = params.username;
+  const userId = await getUserIdByUsername(username);
+
+  if (!userId) {
+    return notFoundError("ユーザーが見つかりません");
+  }
+  try {
+    const isDailyReflectionCount =
+      await reflectionRepository.countSelectedTagReflectionsByUserId(
+        userId,
+        undefined,
+        {
+          isDailyReflection: true
+        }
+      );
+
+    const isLearningCount =
+      await reflectionRepository.countSelectedTagReflectionsByUserId(
+        userId,
+        undefined,
+        { isLearning: true }
+      );
+
+    const isAwarenessCount =
+      await reflectionRepository.countSelectedTagReflectionsByUserId(
+        userId,
+        undefined,
+        { isAwareness: true }
+      );
+
+    const isMonologueCount =
+      await reflectionRepository.countSelectedTagReflectionsByUserId(
+        userId,
+        undefined,
+        { isMonologue: true }
+      );
+
+    const isInputLogCount =
+      await reflectionRepository.countSelectedTagReflectionsByUserId(
+        userId,
+        undefined,
+        {
+          isInputLog: true
+        }
+      );
+
+    return NextResponse.json({
+      isDailyReflection: isDailyReflectionCount,
+      isLearning: isLearningCount,
+      isAwareness: isAwarenessCount,
+      isMonologue: isMonologueCount,
+      isInputLog: isInputLogCount
+    });
+  } catch (error) {
+    return internalServerError("GET", "タグ別の投稿数", error);
+  }
+}


### PR DESCRIPTION
## やったこと
- タグ別投稿のみを取得する新しいAPIを作成

## 動作確認動画(スクリーンショット)
- chiikawasakiに目で見てもらった

## 確認したこと(デグレチェック)
- UIの差分がないこと