### PR TITLE
fix:user入力カラムについて文字数に変換

### DIFF
--- a/lambda-function/backup-func/lambda_function.py
+++ b/lambda-function/backup-func/lambda_function.py
@@ -18,7 +18,6 @@ def lambda_handler(event, context):
 
     table_names = ['Reflection', 'Account', 'User', 'ReflectionFolder']
     csv_file_names = ['Reflection.csv', 'Account.csv', 'User.csv', 'ReflectionFolder.csv']
-
     today = datetime.datetime.utcnow().strftime('%Y-%m-%d')
 
     bucket = 'refty-backup-data'
@@ -34,7 +33,6 @@ def lambda_handler(event, context):
 
             key_today = f'{today}/{csv_file_name}'
             s3_client.put_object(Bucket=bucket, Key=key_today, Body=buffer.getvalue())
-
             if table_name == 'Reflection':
                 buffer.seek(0)
                 csv_reader = csv.reader(buffer)
@@ -48,17 +46,14 @@ def lambda_handler(event, context):
                     content_index = headers.index('content')
                 except ValueError:
                     pass
-                
                 try:
                     title_index = headers.index('title')
                 except ValueError:
                     pass
-
                 try:
                     ai_feedback_index = headers.index('aiFeedback')
                 except ValueError:
                     pass
-                
                 new_buffer = io.StringIO()
                 csv_writer = csv.writer(new_buffer)
                 csv_writer.writerow(headers)
@@ -74,13 +69,11 @@ def lambda_handler(event, context):
 
                     if ai_feedback_index is not None and row[ai_feedback_index]:
                         new_row[ai_feedback_index] = str(len(row[ai_feedback_index]))
-                    
                     csv_writer.writerow(new_row)
                 
                 new_buffer.seek(0)
                 latest_key = f'latest/{csv_file_name}'
                 s3_client.put_object(Bucket=bucket, Key=latest_key, Body=new_buffer.getvalue())
-
             elif table_name == 'User':
                 buffer.seek(0)
                 csv_reader = csv.reader(buffer)

--- a/lambda-function/backup-func/lambda_function.py
+++ b/lambda-function/backup-func/lambda_function.py
@@ -7,10 +7,10 @@ import csv
 
 
 def lambda_handler(event, context):
-    
+    # S3クライアントの作成（Lambda 実行ロールで許可済みと仮定）
     s3_client = boto3.client('s3')
 
-    
+    # DB接続
     db_url = os.getenv('DATABASE_URL')
     if not db_url:
         return {'statusCode': 500, 'body': 'DATABASE_URL環境変数が設定されていません。'}
@@ -18,27 +18,33 @@ def lambda_handler(event, context):
     conn = psycopg2.connect(db_url)
     cur = conn.cursor()
 
+    # テーブルとCSV名の指定
     table_names = ['Reflection', 'Account', 'User', 'ReflectionFolder']
     csv_file_names = ['Reflection.csv', 'Account.csv', 'User.csv', 'ReflectionFolder.csv']
-    
+
+    # 今日の日付を取得
     today = datetime.datetime.utcnow().strftime('%Y-%m-%d')
 
+    # バケット名
     bucket = 'refty-backup-data'
 
     results = []
 
     for table_name, csv_file_name in zip(table_names, csv_file_names):
         try:
+            # CSVデータをメモリ内に書き込む
             buffer = io.StringIO()
             sql = f'COPY "{table_name}" TO STDOUT WITH CSV HEADER'
             cur.copy_expert(sql, buffer)
             buffer.seek(0)
 
+            # S3に今日の日付ディレクトリへ保存（元のままの内容）
             key_today = f'{today}/{csv_file_name}'
             s3_client.put_object(Bucket=bucket, Key=key_today, Body=buffer.getvalue())
-            #Reflectionの場合、文字列カラムを文字数をカウントして保存
-            #TODO USerテーブルについてもユーザーが記入するところがあるので、そこを文字数カウントに修正した方がいい
+
+            # latestディレクトリ用のデータ処理
             if table_name == 'Reflection':
+                # Reflectionテーブルの処理（既存のコード）
                 buffer.seek(0)
                 csv_reader = csv.reader(buffer)
                 headers = next(csv_reader)
@@ -51,31 +57,30 @@ def lambda_handler(event, context):
                     content_index = headers.index('content')
                 except ValueError:
                     pass
+                
                 try:
                     title_index = headers.index('title')
                 except ValueError:
                     pass
+
                 try:
                     ai_feedback_index = headers.index('aiFeedback')
                 except ValueError:
-                    
                     pass
-                
                 
                 new_buffer = io.StringIO()
                 csv_writer = csv.writer(new_buffer)
-                csv_writer.writerow(headers)  
-                
+                csv_writer.writerow(headers)
                 
                 for row in csv_reader:
                     new_row = row.copy()
-                    # 文字数をカウントして保存
+                    
                     if content_index is not None and row[content_index]:
                         new_row[content_index] = str(len(row[content_index]))
                     
                     if title_index is not None and row[title_index]:
                         new_row[title_index] = str(len(row[title_index]))
-                    
+
                     if ai_feedback_index is not None and row[ai_feedback_index]:
                         new_row[ai_feedback_index] = str(len(row[ai_feedback_index]))
                     
@@ -84,7 +89,63 @@ def lambda_handler(event, context):
                 new_buffer.seek(0)
                 latest_key = f'latest/{csv_file_name}'
                 s3_client.put_object(Bucket=bucket, Key=latest_key, Body=new_buffer.getvalue())
-            else:               
+
+            elif table_name == 'User':
+                buffer.seek(0)
+                csv_reader = csv.reader(buffer)
+                headers = next(csv_reader)
+                
+                username_index = None
+                bio_index = None
+                goal_index = None
+                website_index = None
+                
+                try:
+                    username_index = headers.index('username')
+                except ValueError:
+                    pass
+
+                try:
+                    bio_index = headers.index('bio')
+                except ValueError:
+                    pass
+                
+                try:
+                    goal_index = headers.index('goal')
+                except ValueError:
+                    pass
+
+                try:
+                    website_index = headers.index('website')
+                except ValueError:
+                    pass
+                
+                new_buffer = io.StringIO()
+                csv_writer = csv.writer(new_buffer)
+                csv_writer.writerow(headers)
+                
+                for row in csv_reader:
+                    new_row = row.copy()
+                    if username_index is not None and row[username_index]:
+                        new_row[username_index] = str(len(row[username_index]))
+
+                    if bio_index is not None and row[bio_index]:
+                        new_row[bio_index] = str(len(row[bio_index]))
+                    
+                    if goal_index is not None and row[goal_index]:
+                        new_row[goal_index] = str(len(row[goal_index]))
+
+                    if website_index is not None and row[website_index]:
+                        new_row[website_index] = str(len(row[website_index]))
+                    
+                    csv_writer.writerow(new_row)
+                
+                new_buffer.seek(0)
+                latest_key = f'latest/{csv_file_name}'
+                s3_client.put_object(Bucket=bucket, Key=latest_key, Body=new_buffer.getvalue())
+
+            else:
+                # 他のテーブルは通常通り保存
                 buffer.seek(0)
                 latest_key = f'latest/{csv_file_name}'
                 s3_client.put_object(Bucket=bucket, Key=latest_key, Body=buffer.getvalue())
@@ -94,6 +155,7 @@ def lambda_handler(event, context):
         except Exception as e:
             results.append(f"{table_name} のアップロードエラー：{str(e)}")
 
+    # 接続を閉じる
     cur.close()
     conn.close()
 


### PR DESCRIPTION
## やったこと
s3からBigQueryへデータ転送を実行する際、csvファイル内にエスケープ不可能な文字(\や閉じられていない"など)が含まれていた場合、その行が取得できなくなるというエラーが発生していたため、文字列を文字数に変換したのちlatestディレクトリ配下にcsvを格納するように変更した
## 動作確認動画(スクリーンショット)
<img width="887" alt="image" src="https://github.com/user-attachments/assets/ef02f646-2f5b-4ebc-be14-1b45139d4940" />

## 確認したこと(デグレチェック)
正常なユーザー数が取得されていることを確認
## リリース時本番環境で確認すること
確認済み