### PR TITLE
特定のディレクトリ配下の変更以外GitHub Actionsが回らないように変更

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,8 +3,14 @@ name: Playwright Tests
 on:
   push:
     branches: [main, master]
+    paths:
+      - "src/**"
+      - "e2e/**"
   pull_request:
     branches: [main, master]
+    paths:
+      - "src/**"
+      - "e2e/**"
 
 jobs:
   test:


### PR DESCRIPTION
## やったこと
- 特定のディレクトリ配下の変更以外GitHub Actionsが回らないように変更
- 具体的には `src` 配下と `e2e` 配下のみ回る
## 動作確認動画(スクリーンショット)

## 確認したこと(デグレチェック)

## リリース時本番環境で確認すること

## 参考
https://docs.github.com/ja/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
