### PR TITLE
PWAのフッターにレポートへのアイコンを追加

### DIFF
--- a/public/mobile-footer/active-report.svg
+++ b/public/mobile-footer/active-report.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M200-120q-33 0-56.5-23.5T120-200v-640h80v640h640v80H200Zm40-120v-360h160v360H240Zm200 0v-560h160v560H440Zm200 0v-200h160v200H640Z"/></svg>

--- a/public/mobile-footer/report.svg
+++ b/public/mobile-footer/report.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#757575"><path d="M200-120q-33 0-56.5-23.5T120-200v-640h80v640h640v80H200Zm40-120v-360h160v360H240Zm200 0v-560h160v560H440Zm200 0v-200h160v200H640Z"/></svg>

--- a/src/components/footer/mobile/MobileFooter.tsx
+++ b/src/components/footer/mobile/MobileFooter.tsx
@@ -14,7 +14,7 @@ export const MobileFooter = () => {
       width={"100vw"}
       display={"flex"}
       justifyContent={"center"}
-      gap={5.5}
+      gap={session ? 5.5 : 8}
       pt={1}
       pb={3.5}
       position={"sticky"}

--- a/src/components/footer/mobile/MobileFooter.tsx
+++ b/src/components/footer/mobile/MobileFooter.tsx
@@ -14,7 +14,7 @@ export const MobileFooter = () => {
       width={"100vw"}
       display={"flex"}
       justifyContent={"center"}
-      gap={8}
+      gap={5.5}
       pt={1}
       pb={3.5}
       position={"sticky"}
@@ -36,6 +36,11 @@ export const MobileFooter = () => {
             href={`/post`}
             imagePass={"post.svg"}
             alt={"投稿ページへ行くボタン"}
+          />
+          <MobileFooterButton
+            href={`/${session?.user.username}/report`}
+            imagePass={"report.svg"}
+            alt={"マイレポートへ行くボタン"}
           />
           <MobileFooterButton
             href={`/${session?.user.username}`}


### PR DESCRIPTION
## やったこと
- PWAのフッターにレポートへのアイコンを追加
## 動作確認動画(スクリーンショット)


https://github.com/user-attachments/assets/51b518e6-f303-452f-a787-cb932bc1f15a


<img width="330" alt="image" src="https://github.com/user-attachments/assets/d4f08d34-23d6-42f8-8458-c252fc7cfb7e" />
<img width="333" alt="image" src="https://github.com/user-attachments/assets/265759a4-f029-421c-b2b7-ca2480cf256e" />



## 確認したこと(デグレチェック)
- マイレポートにいない時、非アクティブな色になっていること
- マイレポートにいる時、アクティブな色になっていること
- セッションがないときの幅
## リリース時本番環境で確認すること
