### PR TITLE
[bugfix]投稿ページのポップアップ周りの表示崩れを直す

### DIFF
--- a/src/features/routes/post/popup/folder-setting/EmptyFolder.tsx
+++ b/src/features/routes/post/popup/folder-setting/EmptyFolder.tsx
@@ -1,7 +1,7 @@
 import { Typography } from "@mui/material";
 import { theme } from "@/src/utils/theme";
 
-export const NotFoundFolder: React.FC = () => {
+export const EmptyFolder = () => {
   return (
     <Typography
       component={"span"}

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -2,7 +2,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import FolderIcon from "@mui/icons-material/Folder";
 import { Box, Fade, Popper, Typography } from "@mui/material";
 import type { Folder } from "@/src/api/folder-api";
-import { NotFoundFolder } from "./NotFolder";
+import { EmptyFolder } from "./EmptyFolder";
 import { Button } from "@/src/components/button";
 import { label } from "@/src/components/button/TagButton";
 import { theme } from "@/src/utils/theme";
@@ -95,8 +95,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
               borderRadius={4}
             >
               {isFoldersEmpty ? (
-                // TODO: ファイル名を変更する
-                <NotFoundFolder />
+                <EmptyFolder />
               ) : (
                 <>
                   <Typography

--- a/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
+++ b/src/features/routes/post/popup/folder-setting/FolderSettingPopupArea.tsx
@@ -54,7 +54,7 @@ export const FolderSettingPopupArea: React.FC<FolderSettingPopupAreaProps> = ({
           フォルダ
         </Button>
         {selectedFolderUUID ? (
-          <Box display={"flex"} mx={0.4} zIndex={3}>
+          <Box display={"flex"} mx={0.4}>
             <Box
               display={"flex"}
               alignItems={"center"}

--- a/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
+++ b/src/features/routes/post/popup/select-tag/SelectTagPopup.tsx
@@ -49,7 +49,7 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
         </Button>
 
         {activeTags.map((tag) => (
-          <Box key={tag} display={"flex"} mx={0.4} zIndex={3}>
+          <Box key={tag} display={"flex"} mx={0.4}>
             <Box
               display={"flex"}
               alignItems={"center"}
@@ -73,7 +73,7 @@ export const SelectTagPopup: React.FC<TagSelectionPopupProps> = ({
           </Box>
         ))}
       </Box>
-      { /* TODO: disablePortal の動作を確認する */ }
+      {/* TODO: disablePortal の動作を確認する */}
       <Popper
         open={open}
         anchorEl={anchorEl}


### PR DESCRIPTION
## やったこと
- 選択されたフォルダとタグにセットされているzIndexを剥がす
- NotFoderをリネーム

## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/a737a2b0-5fd2-4dda-805d-b41d4af7992e

## 確認したこと(デグレチェック)
- zIndexを剥がして別UIに影響が出ていないこと

## リリース時本番環境で確認すること
- PWA
