### PR TITLE
AIからフィードバックをもらうボタンの表示の条件を変更

### DIFF
--- a/src/app/(multi-footer)/[username]/[reflectionCUID]/page.client.tsx
+++ b/src/app/(multi-footer)/[username]/[reflectionCUID]/page.client.tsx
@@ -111,15 +111,17 @@ const ReflectionDetailPage: React.FC<ReflectionDetailPageProps> = ({
         content={content}
         activeTags={activeTags}
       />
-      <AIFeedbackAreaContainer
-        isCurrentUser={isCurrentUser}
-        reflectionCUID={reflectionCUID}
-        aiFeedback={aiFeedback}
-        content={content}
-        onSendToSQS={handleSendToSQS}
-        setAIType={setAIType}
-        AIType={AIType}
-      />
+      {(isCurrentUser || aiFeedback) && (
+        <AIFeedbackAreaContainer
+          isCurrentUser={isCurrentUser}
+          reflectionCUID={reflectionCUID}
+          aiFeedback={aiFeedback}
+          content={content}
+          onSendToSQS={handleSendToSQS}
+          setAIType={setAIType}
+          AIType={AIType}
+        />
+      )}
       <UserInformationSection
         username={username}
         userImage={userImage}

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -26,7 +26,7 @@ export const AccordionSummary = styled((props: AccordionSummaryProps) => (
     {...props}
   />
 ))({
-  width: "275px",
+  width: "290px",
   padding: 0,
   "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
     transform: "rotate(90deg)"

--- a/src/features/routes/reflection-detail/article/ai-feedback/AIFeedbackAreaContainer.tsx
+++ b/src/features/routes/reflection-detail/article/ai-feedback/AIFeedbackAreaContainer.tsx
@@ -76,12 +76,10 @@ export const AIFeedbackAreaContainer: React.FC<
               <Box display={"flex"} alignItems={"center"}>
                 {!isMobile && (
                   <Box
+                    color={theme.palette.grey[500]}
+                    fontSize={"30px"}
+                    mr={1}
                     component={IoArrowUndoSharp}
-                    sx={{
-                      color: theme.palette.grey[500],
-                      fontSize: "30px",
-                      mr: 1
-                    }}
                   />
                 )}
                 <Typography

--- a/src/features/routes/reflection-detail/article/ai-feedback/AIFeedbackAreaContainer.tsx
+++ b/src/features/routes/reflection-detail/article/ai-feedback/AIFeedbackAreaContainer.tsx
@@ -45,7 +45,10 @@ export const AIFeedbackAreaContainer: React.FC<
     <Accordion>
       <AccordionSummary sx={{ mt: 8 }}>
         <Typography fontSize={17} fontWeight={550} letterSpacing={0.8}>
-          AIからフィードバックをもらう
+          {/* NOTE: フィードバックがすでにある場合、「見る」、まだフィードバックがないかつ自分の投稿の場合は「受け取る」 */}
+          {aiFeedback
+            ? "AIからのフィードバックを見る"
+            : "AIからフィードバックを受け取る"}
         </Typography>
       </AccordionSummary>
       <AccordionDetails sx={{ py: 0.5, px: 0 }}>
@@ -58,14 +61,14 @@ export const AIFeedbackAreaContainer: React.FC<
             onClick={handleSendToSQS}
             disabled={!isAICallButtonEnabled || isLoading || !isCurrentUser}
             sx={{
-              borderRadius: 2,
+              borderRadius: 3,
               bgcolor: theme.palette.primary.contrastText,
               "&:hover": {
                 bgcolor: theme.palette.primary.main
               }
             }}
           >
-            AIからフィードバックをもらう
+            AIからフィードバックを受け取る
           </Button>
           {isAICallButtonEnabled && isCurrentUser && (
             <Box display={"flex"} ml={{ sm: 1 }}>


### PR DESCRIPTION
## やったこと
- フィードバックボタンの表示の有無
  - 自身の投稿であるorすでにAIからフィードバックを受け取っている場合のみフィードバックエリアを表示
    - 自身の投稿ではないときかつAIからフィードバックをもらっていない場合フィードバックエリアを表示しない
- フィードバックボタンの文言を変更
  - AIからフィードバックを受け取っている場合、「AIからのフィードバックを見る」
  - AIからフィードバックを受け取っていない場合、「AIからフィードバックを受け取る」

## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/ca59f8a3-943c-41d2-b1e4-4b8204d55d1d


## 確認したこと(デグレチェック)
- 自身の投稿ではない、かつAIから受け取っていない場合フィードバックエリアが表示されていないこと
  - そうではない場合、フィードバックエリアが表示されていること

## リリース時本番環境で確認すること
- 自身の投稿であるとき
  - AIからフィードバックを受け取ることができること
  - 過去AIからの受け取ったフィードバックが表示されていること
- 自身の投稿ではないとき
  - AIからフィードバックをもらっている投稿にアクセスした時、フィードバックが表示されていること
  - AIからフィードバックをもらっていない投稿にアクセスした時、フィードバックエリアが表示されていないこと

