### PR TITLE
アコーディオンの文言が切れていたのでwidthを調整

### DIFF
--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -26,7 +26,7 @@ export const AccordionSummary = styled((props: AccordionSummaryProps) => (
     {...props}
   />
 ))({
-  width: "290px",
+  width: "300px",
   padding: 0,
   "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
     transform: "rotate(90deg)"

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -26,7 +26,7 @@ export const AccordionSummary = styled((props: AccordionSummaryProps) => (
     {...props}
   />
 ))({
-  width: "300px",
+  width: "295px",
   padding: 0,
   "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
     transform: "rotate(90deg)"


### PR DESCRIPTION
## やったこと
- アコーディオンの文言が切れていたのでwidthを調整
## 動作確認動画(スクリーンショット)
<img width="332" alt="image" src="https://github.com/user-attachments/assets/a9a5b2ae-f350-4663-89ea-7891b9f28bb1" />

## 確認したこと(デグレチェック)

## リリース時本番環境で確認すること
- PWAでの挙動