### PR TITLE
既存の振り返り取得APIを修正

### DIFF
--- a/src/api/profile-api.ts
+++ b/src/api/profile-api.ts
@@ -13,6 +13,8 @@ type Profile = {
   website: string;
 };
 
+type ProfileForMyPage = Omit<Profile, "goal">;
+
 type CheckExists = {
   exists: boolean;
 };
@@ -25,6 +27,17 @@ export const profileAPI = {
       next: { tags: [`profile-${username}`] }
     };
     return await fetchURL<Profile, 404>(path, options);
+  },
+
+  async getUserProfileForMyPage(
+    username: string
+  ): Promise<Result<ProfileForMyPage, 404>> {
+    const path = `/api/${username}/profile`;
+    const options: FetchURLOptions = {
+      method: "GET",
+      next: { tags: [`profile-${username}`] }
+    };
+    return await fetchURL<ProfileForMyPage, 404>(path, options);
   },
 
   async checkUsernameExists(

--- a/src/api/reflection-api.ts
+++ b/src/api/reflection-api.ts
@@ -47,10 +47,6 @@ type ReflectionAll = {
 };
 
 type Reflections = {
-  userImage: string;
-  bio: string;
-  goal: string;
-  website: string;
   reflections: Reflection[];
   totalPage: number;
   filteredReflectionCount: number;

--- a/src/app/(multi-footer)/[username]/page.tsx
+++ b/src/app/(multi-footer)/[username]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import UserReflectionListPage from "./page.client";
 import { folderAPI } from "@/src/api/folder-api";
+import { profileAPI } from "@/src/api/profile-api";
 import { reflectionAPI } from "@/src/api/reflection-api";
 import { reflectionsCountAPI } from "@/src/api/reflections-count-api";
 import { getHeaders } from "@/src/utils/get-headers";
@@ -36,19 +37,22 @@ const page = async ({
   const selectedFolder = searchParams.folder || undefined;
   const status = searchParams.status;
 
-  const [reflectionCount, reflectionsWithUser, folders] = await Promise.all([
-    reflectionsCountAPI.getReflectionsCount(username),
-    reflectionAPI.getReflectionsByUsername(
-      headers,
-      username,
-      currentPage,
-      selectedTag,
-      selectedFolder
-    ),
-    folderAPI.getFolder(username)
-  ]);
+  const [profile, reflectionCount, reflectionsWithUser, folders] =
+    await Promise.all([
+      profileAPI.getUserProfileForMyPage(username),
+      reflectionsCountAPI.getReflectionsCount(username),
+      reflectionAPI.getReflectionsByUsername(
+        headers,
+        username,
+        currentPage,
+        selectedTag,
+        selectedFolder
+      ),
+      folderAPI.getFolder(username)
+    ]);
 
   if (
+    profile === 404 ||
     reflectionCount === 404 ||
     reflectionsWithUser === 404 ||
     folders === 404
@@ -75,10 +79,10 @@ const page = async ({
     <UserReflectionListPage
       currentUsername={session?.username || null}
       currentUserImage={session?.image || null}
-      userImage={reflectionsWithUser.userImage}
       username={username}
-      bio={reflectionsWithUser.bio}
-      website={reflectionsWithUser.website}
+      userImage={profile.image}
+      bio={profile.bio}
+      website={profile.website}
       reflectionCount={reflectionCount}
       reflections={reflectionsWithUser.reflections}
       currentPage={currentPage}

--- a/src/app/(multi-footer)/[username]/page.tsx
+++ b/src/app/(multi-footer)/[username]/page.tsx
@@ -37,8 +37,8 @@ const page = async ({
   const selectedFolder = searchParams.folder || undefined;
   const status = searchParams.status;
 
-  const [profile, reflectionCount, reflectionsWithUser, folders] =
-    await Promise.all([
+  const [profile, reflectionCount, reflectionInfo, folders] = await Promise.all(
+    [
       profileAPI.getUserProfileForMyPage(username),
       reflectionsCountAPI.getReflectionsCount(username),
       reflectionAPI.getReflectionsByUsername(
@@ -49,12 +49,13 @@ const page = async ({
         selectedFolder
       ),
       folderAPI.getFolder(username)
-    ]);
+    ]
+  );
 
   if (
     profile === 404 ||
     reflectionCount === 404 ||
-    reflectionsWithUser === 404 ||
+    reflectionInfo === 404 ||
     folders === 404
   ) {
     return notFound();
@@ -84,10 +85,10 @@ const page = async ({
       bio={profile.bio}
       website={profile.website}
       reflectionCount={reflectionCount}
-      reflections={reflectionsWithUser.reflections}
+      reflections={reflectionInfo.reflections}
       currentPage={currentPage}
-      totalPage={reflectionsWithUser.totalPage}
-      tagCountList={reflectionsWithUser.tagCountList}
+      totalPage={reflectionInfo.totalPage}
+      tagCountList={reflectionInfo.tagCountList}
       randomReflection={randomReflection}
       folders={folders}
     />

--- a/src/app/api/[username]/profile/route.ts
+++ b/src/app/api/[username]/profile/route.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { userRepository } from "@/src/infrastructure/repository/userRepository";
+import { getUserIdByUsername } from "@/src/utils/actions/get-userId-by-username";
+import { internalServerError, notFoundError } from "@/src/utils/http-error";
+
+export async function GET(
+  _: NextRequest,
+  { params }: { params: { username: string } }
+) {
+  const username = params.username;
+  const userId = await getUserIdByUsername(username);
+  if (!userId) {
+    return notFoundError("ユーザーが見つかりません");
+  }
+
+  try {
+    const userProfile = await userRepository.getUserProfileForMyPage({
+      userId
+    });
+
+    if (!userProfile) {
+      return notFoundError("ユーザーのプロフィールが見つかりません");
+    }
+
+    return NextResponse.json({
+      image: userProfile.image,
+      bio: userProfile.bio,
+      website: userProfile.website
+    });
+  } catch (error) {
+    return internalServerError("GET", "ユーザーのプロフィール", error);
+  }
+}

--- a/src/app/api/reflection/[username]/route.ts
+++ b/src/app/api/reflection/[username]/route.ts
@@ -10,11 +10,6 @@ export async function GET(
   { params }: { params: { username: string } }
 ) {
   const username = params.username;
-
-  if (!username) {
-    return notFoundError("ユーザーネームが見つかりません");
-  }
-
   const userId = await getUserIdByUsername(username);
   if (!userId) {
     return notFoundError("ユーザーが見つかりません");
@@ -27,29 +22,21 @@ export async function GET(
     const tag = req.nextUrl.searchParams.get("tag") ?? undefined;
     const folder = req.nextUrl.searchParams.get("folder") ?? undefined;
 
-    const {
-      userWithReflections,
-      totalPage,
-      filteredReflectionCount,
-      tagCountList
-    } = await reflectionService.getByUsername(
-      userId,
-      isCurrentUser,
-      page,
-      tag,
-      folder
-    );
+    const { reflections, totalPage, filteredReflectionCount, tagCountList } =
+      await reflectionService.getByUsername(
+        userId,
+        isCurrentUser,
+        page,
+        tag,
+        folder
+      );
 
-    if (!userWithReflections) {
+    if (!reflections) {
       return notFoundError("ユーザーの振り返り一覧が見つかりません");
     }
 
     return NextResponse.json({
-      reflections: userWithReflections.reflections,
-      userImage: userWithReflections.image,
-      bio: userWithReflections.bio,
-      goal: userWithReflections.goal,
-      website: userWithReflections.website,
+      reflections,
       totalPage,
       filteredReflectionCount,
       tagCountList

--- a/src/infrastructure/repository/reflectionRepository.ts
+++ b/src/infrastructure/repository/reflectionRepository.ts
@@ -51,7 +51,7 @@ export const reflectionRepository = {
     });
   },
 
-  async getUserWithReflections(params: {
+  async getUserReflections(params: {
     userId: string;
     isCurrentUser: boolean;
     tagFilter?: Record<string, boolean>;
@@ -61,34 +61,23 @@ export const reflectionRepository = {
   }) {
     const { userId, isCurrentUser, tagFilter, folderFilter, offset, limit } =
       params;
-    return prisma.user.findUnique({
+    return prisma.reflection.findMany({
       where: {
-        id: userId
+        userId,
+        isPublic: isCurrentUser ? undefined : true,
+        ...tagFilter,
+        folderUUID: folderFilter
       },
+      orderBy: [{ isPinned: "desc" }, { createdAt: "desc" }],
+      take: limit,
+      skip: offset,
       select: {
-        image: true,
-        bio: true,
-        goal: isCurrentUser && true,
-        website: true,
-        reflections: {
-          where: {
-            userId,
-            isPublic: isCurrentUser ? undefined : true,
-            ...tagFilter,
-            folderUUID: folderFilter
-          },
-          orderBy: [{ isPinned: "desc" }, { createdAt: "desc" }],
-          take: limit,
-          skip: offset,
-          select: {
-            title: true,
-            reflectionCUID: true,
-            charStamp: true,
-            createdAt: true,
-            isPublic: true,
-            isPinned: true
-          }
-        }
+        title: true,
+        reflectionCUID: true,
+        charStamp: true,
+        createdAt: true,
+        isPublic: true,
+        isPinned: true
       }
     });
   },

--- a/src/infrastructure/repository/userRepository.ts
+++ b/src/infrastructure/repository/userRepository.ts
@@ -17,6 +17,19 @@ export const userRepository = {
     });
   },
 
+  async getUserProfileForMyPage(params: { userId: string }) {
+    const { userId } = params;
+    return prisma.user.findUnique({
+      where: {
+        id: userId
+      },
+      select: {
+        image: true,
+        bio: true,
+        website: true
+      }
+    });
+  },
   async getUserProfileForReport(params: { username: string }) {
     const { username } = params;
 

--- a/src/service/reflectionService.ts
+++ b/src/service/reflectionService.ts
@@ -86,15 +86,14 @@ export const reflectionService = {
 
     const totalPage = Math.ceil(filteredReflectionCount / COUNT_PER_PAGE);
 
-    const userWithReflections =
-      await reflectionRepository.getUserWithReflections({
-        userId,
-        isCurrentUser,
-        tagFilter,
-        folderFilter,
-        offset,
-        limit: COUNT_PER_PAGE
-      });
+    const reflections = await reflectionRepository.getUserReflections({
+      userId,
+      isCurrentUser,
+      tagFilter,
+      folderFilter,
+      offset,
+      limit: COUNT_PER_PAGE
+    });
 
     // MEMO: タグ別の投稿数を全て取得しておく
     const isPublic = isCurrentUser ? undefined : true;
@@ -146,7 +145,7 @@ export const reflectionService = {
     };
 
     return {
-      userWithReflections,
+      reflections,
       totalPage,
       filteredReflectionCount,
       tagCountList


### PR DESCRIPTION
## 背景
- マイページに新機能を実装時、既存の振り返り取得APIに追加実装が入るため
  - 複雑化を防ぐため

## やったこと
- api/reflection/{username}のリファクタリング
  - profile情報は別APIで取ってくる

## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/ee861bf0-d161-419a-82dd-7e03fe3dbccd


## 確認したこと(デグレチェック)
- 自身のマイページは全てのデータを取得していること
- 自身でないマイページは公開投稿のデータのみを取得していること
- プロフィールを取得できていること

## リリース時本番環境で確認すること
- 自身のマイページは全てのデータを取得していること
- 自身でないマイページは公開投稿のデータのみを取得していること
- プロフィールを取得できていること