### PR TITLE
投稿の画像のテーブルを追加

### DIFF
--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Reflection {
   folderUUID        String?
   user              User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   folder            ReflectionFolder? @relation("ReflectionFolder", fields: [folderUUID], references: [folderUUID])
+  images            ReflectionImage[]
 }
 
 model ReflectionFolder {
@@ -68,4 +69,13 @@ model Account {
   session_state     String?
   user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   @@unique([provider, providerAccountId])
+}
+
+model ReflectionImage {
+  id              String     @id @default(uuid())
+  reflectionCUID  String
+  imageUrl        String
+  orderIndex      Int
+  createdAt       DateTime   @default(now())
+  reflection      Reflection @relation(fields: [reflectionCUID], references: [reflectionCUID], onDelete: Cascade)
 }

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   goal               String?
   website            String?
   isReportOpen       Boolean           @default(false)
+  reflectionImages   ReflectionImage[]
 }
 
 model Reflection {
@@ -73,9 +74,11 @@ model Account {
 
 model ReflectionImage {
   id              String     @id @default(uuid())
+  userId          String
   reflectionCUID  String
   imageUrl        String
   orderIndex      Int
   createdAt       DateTime   @default(now())
   reflection      Reflection @relation(fields: [reflectionCUID], references: [reflectionCUID], onDelete: Cascade)
+  user            User       @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -23,7 +23,6 @@ model User {
   goal               String?
   website            String?
   isReportOpen       Boolean           @default(false)
-  reflectionImages   ReflectionImage[]
 }
 
 model Reflection {
@@ -55,6 +54,16 @@ model ReflectionFolder {
   user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
+
+model ReflectionImage {
+  id              String     @id @default(uuid())
+  reflectionCUID  String
+  imageUrl        String
+  orderIndex      Int
+  createdAt       DateTime   @default(now())
+  reflection      Reflection @relation(fields: [reflectionCUID], references: [reflectionCUID], onDelete: Cascade)
+}
+
 model Account {
   id                String   @id @default(uuid())
   userId            String
@@ -72,13 +81,3 @@ model Account {
   @@unique([provider, providerAccountId])
 }
 
-model ReflectionImage {
-  id              String     @id @default(uuid())
-  userId          String
-  reflectionCUID  String
-  imageUrl        String
-  orderIndex      Int
-  createdAt       DateTime   @default(now())
-  reflection      Reflection @relation(fields: [reflectionCUID], references: [reflectionCUID], onDelete: Cascade)
-  user            User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-}


### PR DESCRIPTION
## やったこと
- スキーマを編集
``` 
| フィールド名          | 型                           | 説明                         |
|---------------------|------------------------------|------------------------------|
| id                  | String @id @default(uuid())  | 画像レコードの一意識別子         |
| userId              | String                       | 関連するUserのID               |
| reflectionCUID      | String                       | 関連するReflectionのID        | 
| imageUrl            | String                       | 画像のURL                     |
| orderIndex          | Int                          | 画像の表示順序                 |
| createdAt           | DateTime @default(now())     | 作成日時                      |
```
- ユーザーに対して1対多になるように設計
- 投稿に対して1対多になるように設計
## 見て欲しいところ
- 足りていないカラムがあるか（今後必要になりそうなもの）
- userとの関連は必要か否か
## 備考
- マイグレーションをこの後する
