### PR TITLE
useAutoSaveのリファクタリング

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
     "supabase",
     "REFTY",
     "networkidle",
-    "yusei53"
+    "yusei53",
+    "uuidv4"
   ],
 
   "editor.tabSize": 2,

--- a/src/app/(base-footer)/post/page.client.tsx
+++ b/src/app/(base-footer)/post/page.client.tsx
@@ -41,15 +41,7 @@ const ReflectionPostFormPage: React.FC<ReflectionPostFormPageProps> = ({
   } = useCreateReflectionForm(username, stop);
 
   const { deleteDraft, draftList, currentDraftId, handleDraftChange } =
-    useAutoSave(
-      watch,
-      selectedEmoji,
-      selectedFolderUUID,
-      isSubmitSuccessful,
-      reset,
-      handleEmojiChange,
-      handleFolderChange
-    );
+    useAutoSave(watch, isSubmitSuccessful, reset);
 
   useWarningDialog(isDirty, isSubmitSuccessful);
 

--- a/src/app/_client/hooks/reflection/useAutoSave.ts
+++ b/src/app/_client/hooks/reflection/useAutoSave.ts
@@ -5,7 +5,7 @@ import { useDraftId } from "./useDraftId";
 
 export type DraftData = {
   formData: CreateReflectionSchemaType;
-  lastSaved: number;
+  lastSaved: number; // NOTE: 経過時間の計算だけなら number型でOK
 };
 
 export type DraftDataList = {

--- a/src/app/_client/hooks/reflection/useDraftId.ts
+++ b/src/app/_client/hooks/reflection/useDraftId.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from "react";
+import { v4 as uuidv4 } from "uuid";
+
+export const useDraftId = () => {
+  const [draftId, setDraftId] = useState<string>("");
+
+  useEffect(() => {
+    setDraftId(uuidv4());
+  }, []);
+
+  return [draftId, setDraftId] as const;
+};


### PR DESCRIPTION
## やったこと
- 謎コードを排除
  - リーダブルなコードを意識した
  - 読み手は地獄だと思うのでuseEffect内はコメントで対応
  - 毎秒レンダーされるのではなく、操作があった1秒後に1回だけ保存する
- スタンプとフォルダの保存まではしない方向にした
  -  現状タグのみ保存されない状況だったが、そうなると逆にバグだと捉えられやすい
    - 我々が解決したいのはtitleとcontentなので、それとコード内部の複雑さを考慮した結果、フォルダとスタンプは見ないでいいという判断


## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/89994596-5239-4cb9-a118-014dc8f65f21



## 確認したこと(デグレチェック)
- 下書きが保存されること
- 下書きを押したら意図したデータが反映されること
- 下書きを切り替えることができること
- 正常に投稿ができること
- 下書きを消すことができること
