### PR TITLE
どんな画像形式でも画像投稿ができるように修正

### DIFF
--- a/src/app/_client/features/common/post-form/ReflectionPostForm.tsx
+++ b/src/app/_client/features/common/post-form/ReflectionPostForm.tsx
@@ -11,6 +11,7 @@ import type {
 } from "react-hook-form";
 import { reflectionAPI } from "../../../api/reflection-api";
 import { useAutoSave } from "../../../hooks/reflection/useAutoSave";
+import { sanitizeFileName } from "../../../utils/sanitize-file-name";
 import EmojiPicker from "../../routes/post/emoji/EmojiPicker";
 import { ImageUploadButton } from "../../routes/post/image-upload/ImageUploadButton";
 import { MarkdownEditor } from "../../routes/post/markdown-editor";
@@ -164,9 +165,9 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
 
   const toggleNightMode = () => setIsNightMode(!isNightMode);
 
-  const handleInsertImage = async (file: File) => {
-    // TODO: 切り出し
+  //TODO: 切り出し
 
+  const handleFileUpload = async (file: File) => {
     // NOTE: 画像のサイズを5MBに制限
     const MAX_FILE_SIZE = 5 * 1024 * 1024;
     if (file.size > MAX_FILE_SIZE) {
@@ -174,8 +175,17 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
       return;
     }
 
+    // MEMO: ファイル名を安全な形式に変換
+    const safeFileName = sanitizeFileName(file.name);
+
+    // MEMO: 新しいFileオブジェクトを作成（元のファイルの内容はそのまま）
+    const safeFile = new File([file], safeFileName, {
+      type: file.type,
+      lastModified: file.lastModified
+    });
+
     const formData = new FormData();
-    formData.append("file", file);
+    formData.append("file", safeFile);
 
     const res = await reflectionAPI.uploadReflectionImage(formData);
 
@@ -251,7 +261,7 @@ const ReflectionPostForm: React.FC<ReflectionPostFormProps> = ({
               )}
             </Box>
             <Box display={"flex"}>
-              <ImageUploadButton onImageSelect={handleInsertImage} />
+              <ImageUploadButton onImageSelect={handleFileUpload} />
               <ReflectionTemplatePopupAreaContainer
                 onInsertTemplate={handleInsertTemplate}
                 onClearContent={handleClearContent}

--- a/src/app/_client/utils/sanitize-file-name/index.ts
+++ b/src/app/_client/utils/sanitize-file-name/index.ts
@@ -1,0 +1,1 @@
+export { sanitizeFileName } from "./sanitizeFileName";

--- a/src/app/_client/utils/sanitize-file-name/sanitizeFileName.ts
+++ b/src/app/_client/utils/sanitize-file-name/sanitizeFileName.ts
@@ -1,0 +1,23 @@
+export const sanitizeFileName = (fileName: string): string => {
+  // MEMO: 拡張子を取得
+  const extension = fileName.split(".").pop() || "";
+  // MEMO: 拡張子を除いたファイル名を取得
+  const nameWithoutExt = fileName.slice(0, fileName.lastIndexOf("."));
+
+  // MEMO: ファイル名を安全な形式に変換
+  const sanitized = nameWithoutExt
+    // MEMO: 日本語を英数字に変換（例：スクリーンショット → screenshot）
+    .replace(/[^\x00-\x7F]/g, "")
+    // MEMO: スペースをハイフンに変換
+    .replace(/\s+/g, "-")
+    // MEMO: 特殊文字を除去
+    .replace(/[^a-zA-Z0-9-]/g, "")
+    // MEMO: 連続するハイフンを1つに
+    .replace(/-+/g, "-")
+    // MEMO: 先頭と末尾のハイフンを除去
+    .replace(/^-+|-+$/g, "")
+    // MEMO: 小文字に変換
+    .toLowerCase();
+
+  return `${sanitized}.${extension}`;
+};

--- a/src/app/_client/utils/sanitize-file-name/sanitizeFileName.ts
+++ b/src/app/_client/utils/sanitize-file-name/sanitizeFileName.ts
@@ -1,3 +1,4 @@
+// MEMO: ファイル名を安全な形式に変換する関数
 export const sanitizeFileName = (fileName: string): string => {
   // MEMO: 拡張子を取得
   const extension = fileName.split(".").pop() || "";


### PR DESCRIPTION
## やったこと
- 画像の名前がStoregeの名前に違反している時に変換する処理を追加
## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/57ffa8a8-8255-4830-9e67-3dbf543e43bc


## 確認したこと(デグレチェック)
- Macのスクリーンショットの時の名前（スペースが入っている、日本が入っている）で投稿できることを確認
## リリース時本番環境で確認すること
- 画像の名前に特殊文字が入っていても画像のプレビューが見れるかどうか