### PR TITLE
投稿数のヒートマップを年毎に見れるように修正

### DIFF
--- a/src/app/_client/features/common/user-menu/UserMenuHeader.tsx
+++ b/src/app/_client/features/common/user-menu/UserMenuHeader.tsx
@@ -68,6 +68,7 @@ export const UserMenuHeader: React.FC<UserMenuHeaderProps> = ({
         transition
         placement={"bottom-end"}
         disablePortal
+        sx={{ zIndex: 1 }}
         modifiers={[
           {
             name: "offset",

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
@@ -1,11 +1,12 @@
 import { memo, useEffect, useRef } from "react";
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import type { ReflectionPerDate } from "@/src/app/_client/api/reflections-count-api";
 import type { ReactCalendarHeatmapValue } from "react-calendar-heatmap";
 import "react-calendar-heatmap/dist/styles.css";
 import "./calendar.css";
 import Calendar from "./Calendar";
 import ToggleJapaneseLabel from "./ToggleJapaneseLabel";
+import { Button } from "@/src/app/_client/components/button";
 import { useToggleJapaneseLabels } from "@/src/app/_client/hooks/calendar/useToggleJapaneseLabels";
 import { useResponsive } from "@/src/app/_client/hooks/responsive/useResponsive";
 import { theme } from "@/src/app/_client/utils/theme";
@@ -108,11 +109,20 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
         </Box>
       </Box>
       <Box display={"flex"} flexDirection={"column"} mt={5} gap={2}>
-        {reflectionYears.map((year) => (
+        {[...reflectionYears].reverse().map((year) => (
           <Button
             key={year}
             onClick={() => onYearClick(year)}
-            sx={{ backgroundColor: theme.palette.grey[100] }}
+            sx={{
+              backgroundColor:
+                targetYear === year ? theme.palette.grey[200] : "white",
+              color: theme.palette.grey[600],
+              border: "none",
+              borderRadius: 1.5,
+              "&:hover": {
+                backgroundColor: theme.palette.grey[100]
+              }
+            }}
           >
             {year}
           </Button>

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
@@ -22,11 +22,10 @@ type CalendarAreaProps = {
   ) => Record<string, string>;
   totalReflections: string;
   targetYear: number | null;
+  reflectionYears: number[];
   onClick: (value: ReactCalendarHeatmapValue<string> | undefined) => void;
   onYearClick: (year: number) => void;
 };
-
-const YEAR_BUTTONS = [2025, 2024];
 
 const CalendarArea: React.FC<CalendarAreaProps> = ({
   startDate,
@@ -36,6 +35,7 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
   tooltipDataAttrs,
   totalReflections,
   targetYear,
+  reflectionYears,
   onClick,
   onYearClick
 }) => {
@@ -108,7 +108,7 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
         </Box>
       </Box>
       <Box display={"flex"} flexDirection={"column"} mt={5} gap={2}>
-        {YEAR_BUTTONS.map((year) => (
+        {reflectionYears.map((year) => (
           <Button
             key={year}
             onClick={() => onYearClick(year)}

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useRef } from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import type { ReflectionPerDate } from "@/src/app/_client/api/reflections-count-api";
 import type { ReactCalendarHeatmapValue } from "react-calendar-heatmap";
 import "react-calendar-heatmap/dist/styles.css";
@@ -23,6 +23,8 @@ type CalendarAreaProps = {
   totalReflections: string;
   onClick: (value: ReactCalendarHeatmapValue<string> | undefined) => void;
 };
+
+const YEAR_BUTTONS = [2025, 2024];
 
 const CalendarArea: React.FC<CalendarAreaProps> = ({
   startDate,
@@ -52,52 +54,61 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
     useToggleJapaneseLabels();
 
   return (
-    <Box mt={5} mb={3} mx={3}>
-      {isMobile && <ToggleJapaneseLabel onToggleLabel={handleToggleLabels} />}
-      <Box
-        display={"flex"}
-        justifyContent={{ sm: "space-between" }}
-        alignItems={"center"}
-        mb={0.5}
-      >
-        <Typography mx={1} fontSize={15}>
-          {isJapanese
-            ? `直近1年間で ${totalReflections} 回振り返りをしています`
-            : `${totalReflections} reflections in the last year`}
-        </Typography>
-        {!isMobile && (
-          <ToggleJapaneseLabel onToggleLabel={handleToggleLabels} />
-        )}
-      </Box>
-      <Box
-        ref={calendarRef}
-        border={`1px solid ${theme.palette.grey[400]}`}
-        borderRadius={2}
-        p={"12px 16px 8px 4px"}
-      >
-        {/* MEMO: 900px以下でスクロール可能にするにするためのBoxコンポーネント */}
+    <Box display={"flex"} flexDirection={"row"}>
+      <Box mt={5} mb={3} mx={3} sx={{ flex: 1, minWidth: 0 }}>
+        {isMobile && <ToggleJapaneseLabel onToggleLabel={handleToggleLabels} />}
         <Box
-          ref={scrollContainerRef}
-          sx={{
-            overflowX: isMobile ? "auto" : "visible"
-          }}
+          display={"flex"}
+          justifyContent={{ sm: "space-between" }}
+          alignItems={"center"}
+          mb={0.5}
         >
-          <Box minWidth={isMobile ? "780px" : "100%"}>
-            <Calendar
-              startDate={startDate}
-              endDate={endDate}
-              values={values}
-              classForValue={(value) => {
-                const baseClass = classForValue(value);
-                return `${baseClass} ${value ? "clickable" : ""}`;
-              }}
-              tooltipDataAttrs={tooltipDataAttrs}
-              showWeekdayLabels
-              gutterSize={2}
-              onClick={onClick}
-            />
+          <Typography mx={1} fontSize={15}>
+            {isJapanese
+              ? `直近1年間で ${totalReflections} 回振り返りをしています`
+              : `${totalReflections} reflections in the last year`}
+          </Typography>
+          {!isMobile && (
+            <ToggleJapaneseLabel onToggleLabel={handleToggleLabels} />
+          )}
+        </Box>
+        <Box
+          ref={calendarRef}
+          border={`1px solid ${theme.palette.grey[400]}`}
+          borderRadius={2}
+          p={"12px 16px 8px 4px"}
+        >
+          {/* MEMO: 900px以下でスクロール可能にするにするためのBoxコンポーネント */}
+          <Box
+            ref={scrollContainerRef}
+            sx={{
+              overflowX: isMobile ? "auto" : "visible"
+            }}
+          >
+            <Box minWidth={isMobile ? "780px" : "100%"}>
+              <Calendar
+                startDate={startDate}
+                endDate={endDate}
+                values={values}
+                classForValue={(value) => {
+                  const baseClass = classForValue(value);
+                  return `${baseClass} ${value ? "clickable" : ""}`;
+                }}
+                tooltipDataAttrs={tooltipDataAttrs}
+                showWeekdayLabels
+                gutterSize={2}
+                onClick={onClick}
+              />
+            </Box>
           </Box>
         </Box>
+      </Box>
+      <Box display={"flex"} flexDirection={"column"} mt={5} gap={2}>
+        {YEAR_BUTTONS.map((year) => (
+          <Button key={year} sx={{ backgroundColor: theme.palette.grey[100] }}>
+            {year}
+          </Button>
+        ))}
       </Box>
     </Box>
   );

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
@@ -21,6 +21,7 @@ type CalendarAreaProps = {
     value: ReactCalendarHeatmapValue<string> | undefined
   ) => Record<string, string>;
   totalReflections: string;
+  targetYear: number | null;
   onClick: (value: ReactCalendarHeatmapValue<string> | undefined) => void;
   onYearClick: (year: number) => void;
 };
@@ -34,6 +35,7 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
   classForValue,
   tooltipDataAttrs,
   totalReflections,
+  targetYear,
   onClick,
   onYearClick
 }) => {
@@ -67,8 +69,8 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
         >
           <Typography mx={1} fontSize={15}>
             {isJapanese
-              ? `直近1年間で ${totalReflections} 回振り返りをしています`
-              : `${totalReflections} reflections in the last year`}
+              ? `${targetYear ? `${targetYear}年に` : "直近1年間で"} ${totalReflections} 回振り返りをしています`
+              : `${totalReflections} reflections in ${targetYear || "the last year"}`}
           </Typography>
           {!isMobile && (
             <ToggleJapaneseLabel onToggleLabel={handleToggleLabels} />

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarArea.tsx
@@ -22,6 +22,7 @@ type CalendarAreaProps = {
   ) => Record<string, string>;
   totalReflections: string;
   onClick: (value: ReactCalendarHeatmapValue<string> | undefined) => void;
+  onYearClick: (year: number) => void;
 };
 
 const YEAR_BUTTONS = [2025, 2024];
@@ -33,7 +34,8 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
   classForValue,
   tooltipDataAttrs,
   totalReflections,
-  onClick
+  onClick,
+  onYearClick
 }) => {
   const { isMobile } = useResponsive();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -105,7 +107,11 @@ const CalendarArea: React.FC<CalendarAreaProps> = ({
       </Box>
       <Box display={"flex"} flexDirection={"column"} mt={5} gap={2}>
         {YEAR_BUTTONS.map((year) => (
-          <Button key={year} sx={{ backgroundColor: theme.palette.grey[100] }}>
+          <Button
+            key={year}
+            onClick={() => onYearClick(year)}
+            sx={{ backgroundColor: theme.palette.grey[100] }}
+          >
             {year}
           </Button>
         ))}

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarAreaFetcher.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarAreaFetcher.tsx
@@ -8,7 +8,7 @@ import type {
 import type { ReactCalendarHeatmapValue } from "react-calendar-heatmap";
 import CalendarArea from "./CalendarArea";
 import { getColor } from "./get-color";
-import { getOneYearAgo } from "@/src/app/_shared/date-helper/date-helpers";
+import { useReflectionHeatmap } from "@/src/app/_client/hooks/calendar/useReflectionHeatmap";
 type CalendarAreaFetcherProps = {
   reflectionCount: ReflectionsCount;
 };
@@ -24,22 +24,7 @@ export const CalendarAreaFetcher: React.FC<CalendarAreaFetcherProps> = ({
   const parsedYear = yearParam ? Number.parseInt(yearParam, 10) : NaN;
   const targetYear = Number.isNaN(parsedYear) ? null : parsedYear;
 
-  const startDateCalc = (targetYear: number | null): Date => {
-    if (targetYear !== null) {
-      return new Date(targetYear, 0, 1);
-    }
-    return getOneYearAgo();
-  };
-
-  const endDateCalc = (targetYear: number | null): Date => {
-    if (targetYear !== null) {
-      return new Date(targetYear, 11, 31);
-    }
-    return new Date();
-  };
-
-  const startDate = startDateCalc(targetYear);
-  const endDate = endDateCalc(targetYear);
+  const { startDate, endDate } = useReflectionHeatmap(targetYear);
 
   const classForValue = useCallback(
     (value: ReactCalendarHeatmapValue<string> | undefined): string => {

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarAreaFetcher.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarAreaFetcher.tsx
@@ -24,10 +24,11 @@ export const CalendarAreaFetcher: React.FC<CalendarAreaFetcherProps> = ({
   const parsedYear = yearParam ? Number.parseInt(yearParam, 10) : NaN;
   const targetYear = Number.isNaN(parsedYear) ? null : parsedYear;
 
-  const { startDate, endDate, totalReflections } = useReflectionHeatmap({
-    targetYear,
-    reflectionCount
-  });
+  const { startDate, endDate, totalReflections, reflectionYears } =
+    useReflectionHeatmap({
+      targetYear,
+      reflectionCount
+    });
 
   const classForValue = useCallback(
     (value: ReactCalendarHeatmapValue<string> | undefined): string => {
@@ -90,6 +91,7 @@ export const CalendarAreaFetcher: React.FC<CalendarAreaFetcherProps> = ({
         tooltipDataAttrs={tooltipDataAttrs}
         totalReflections={totalReflections}
         targetYear={targetYear}
+        reflectionYears={reflectionYears}
         onClick={handleCalendarClick}
         onYearClick={handleYearClick}
       />

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarAreaFetcher.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarAreaFetcher.tsx
@@ -9,7 +9,6 @@ import type { ReactCalendarHeatmapValue } from "react-calendar-heatmap";
 import CalendarArea from "./CalendarArea";
 import { getColor } from "./get-color";
 import { getOneYearAgo } from "@/src/app/_shared/date-helper/date-helpers";
-
 type CalendarAreaFetcherProps = {
   reflectionCount: ReflectionsCount;
 };
@@ -20,8 +19,27 @@ export const CalendarAreaFetcher: React.FC<CalendarAreaFetcherProps> = ({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const startDate = getOneYearAgo();
-  const endDate = new Date();
+
+  const yearParam = searchParams?.get("year") ?? null;
+  const parsedYear = yearParam ? Number.parseInt(yearParam, 10) : NaN;
+  const targetYear = Number.isNaN(parsedYear) ? null : parsedYear;
+
+  const startDateCalc = (targetYear: number | null): Date => {
+    if (targetYear !== null) {
+      return new Date(targetYear, 0, 1);
+    }
+    return getOneYearAgo();
+  };
+
+  const endDateCalc = (targetYear: number | null): Date => {
+    if (targetYear !== null) {
+      return new Date(targetYear, 11, 31);
+    }
+    return new Date();
+  };
+
+  const startDate = startDateCalc(targetYear);
+  const endDate = endDateCalc(targetYear);
 
   const classForValue = useCallback(
     (value: ReactCalendarHeatmapValue<string> | undefined): string => {
@@ -62,6 +80,18 @@ export const CalendarAreaFetcher: React.FC<CalendarAreaFetcherProps> = ({
     [router, pathname, searchParams]
   );
 
+  const handleYearClick = useCallback(
+    (year: number) => {
+      if (!searchParams) {
+        return;
+      }
+      const current = new URLSearchParams(Array.from(searchParams.entries()));
+      current.set("year", String(year));
+      router.push(`${pathname}?${current.toString()}`);
+    },
+    [router, pathname, searchParams]
+  );
+
   return (
     <>
       <CalendarArea
@@ -72,6 +102,7 @@ export const CalendarAreaFetcher: React.FC<CalendarAreaFetcherProps> = ({
         tooltipDataAttrs={tooltipDataAttrs}
         totalReflections={reflectionCount.totalReflections}
         onClick={handleCalendarClick}
+        onYearClick={handleYearClick}
       />
       <Tooltip id="tooltip-data-attrs" />
     </>

--- a/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarAreaFetcher.tsx
+++ b/src/app/_client/features/routes/reflection-list/profile/calendar/CalendarAreaFetcher.tsx
@@ -24,7 +24,10 @@ export const CalendarAreaFetcher: React.FC<CalendarAreaFetcherProps> = ({
   const parsedYear = yearParam ? Number.parseInt(yearParam, 10) : NaN;
   const targetYear = Number.isNaN(parsedYear) ? null : parsedYear;
 
-  const { startDate, endDate } = useReflectionHeatmap(targetYear);
+  const { startDate, endDate, totalReflections } = useReflectionHeatmap({
+    targetYear,
+    reflectionCount
+  });
 
   const classForValue = useCallback(
     (value: ReactCalendarHeatmapValue<string> | undefined): string => {
@@ -85,7 +88,8 @@ export const CalendarAreaFetcher: React.FC<CalendarAreaFetcherProps> = ({
         values={reflectionCount.reflectionsPerDate}
         classForValue={classForValue}
         tooltipDataAttrs={tooltipDataAttrs}
-        totalReflections={reflectionCount.totalReflections}
+        totalReflections={totalReflections}
+        targetYear={targetYear}
         onClick={handleCalendarClick}
         onYearClick={handleYearClick}
       />

--- a/src/app/_client/hooks/calendar/useReflectionHeatmap.ts
+++ b/src/app/_client/hooks/calendar/useReflectionHeatmap.ts
@@ -1,6 +1,16 @@
+import { useMemo } from "react";
+import type { ReflectionsCount } from "../../api/reflections-count-api";
 import { getOneYearAgo } from "@/src/app/_shared/date-helper/date-helpers";
 
-export const useReflectionHeatmap = (targetYear: number | null) => {
+type UseReflectionHeatmapProps = {
+  targetYear: number | null;
+  reflectionCount: ReflectionsCount;
+};
+
+export const useReflectionHeatmap = ({
+  targetYear,
+  reflectionCount
+}: UseReflectionHeatmapProps) => {
   const startDateCalc = (targetYear: number | null): Date => {
     if (targetYear !== null) {
       return new Date(targetYear, 0, 1);
@@ -17,5 +27,20 @@ export const useReflectionHeatmap = (targetYear: number | null) => {
 
   const startDate = startDateCalc(targetYear);
   const endDate = endDateCalc(targetYear);
-  return { startDate, endDate };
+
+  // MEMO: 年ごとの投稿数を計算する
+  const totalReflections = useMemo(() => {
+    if (targetYear !== null) {
+      return String(
+        reflectionCount.reflectionsPerDate
+          .filter((reflection) =>
+            reflection.date.startsWith(targetYear.toString())
+          )
+          .reduce((acc, reflection) => acc + reflection.countReflections, 0)
+      );
+    }
+    return String(reflectionCount.totalReflections);
+  }, [targetYear, reflectionCount]);
+
+  return { startDate, endDate, totalReflections };
 };

--- a/src/app/_client/hooks/calendar/useReflectionHeatmap.ts
+++ b/src/app/_client/hooks/calendar/useReflectionHeatmap.ts
@@ -42,5 +42,24 @@ export const useReflectionHeatmap = ({
     return String(reflectionCount.totalReflections);
   }, [targetYear, reflectionCount]);
 
-  return { startDate, endDate, totalReflections };
+  const oldestYear = useMemo(() => {
+    return reflectionCount.reflectionsPerDate.reduce((acc, reflection) => {
+      return Math.min(acc, Number(reflection.date.split("-")[0]));
+    }, Infinity);
+  }, [reflectionCount]);
+
+  const newestYear = useMemo(() => {
+    return new Date().getFullYear();
+  }, []);
+
+  // MEMO: 投稿がある一番古い年からの配列
+  const reflectionYears = useMemo(() => {
+    const years = [];
+    for (let i = oldestYear; i <= newestYear; i++) {
+      years.push(i);
+    }
+    return years;
+  }, [oldestYear, newestYear]);
+
+  return { startDate, endDate, totalReflections, reflectionYears };
 };

--- a/src/app/_client/hooks/calendar/useReflectionHeatmap.ts
+++ b/src/app/_client/hooks/calendar/useReflectionHeatmap.ts
@@ -1,0 +1,21 @@
+import { getOneYearAgo } from "@/src/app/_shared/date-helper/date-helpers";
+
+export const useReflectionHeatmap = (targetYear: number | null) => {
+  const startDateCalc = (targetYear: number | null): Date => {
+    if (targetYear !== null) {
+      return new Date(targetYear, 0, 1);
+    }
+    return getOneYearAgo();
+  };
+
+  const endDateCalc = (targetYear: number | null): Date => {
+    if (targetYear !== null) {
+      return new Date(targetYear, 11, 31);
+    }
+    return new Date();
+  };
+
+  const startDate = startDateCalc(targetYear);
+  const endDate = endDateCalc(targetYear);
+  return { startDate, endDate };
+};


### PR DESCRIPTION
## やったこと
- 投稿数のヒートマップを年毎に見れるように修正
## 動作確認動画(スクリーンショット)

https://github.com/user-attachments/assets/61488c22-9a4f-48a6-8f85-5dd9e61c52b1


## 確認したこと(デグレチェック)
- 2024、2025の投稿が正しく表示されること
## リリース時本番環境で確認すること
- 2024の投稿と投稿数がきちんと表示されていること
- 2025の投稿と投稿数がきちんと表示されていること
- 2024の投稿がない時に2024のボタンが表示されないこと

## 実装概要
- 年毎のボタンを押すとクエリパラメータに追加され、それを元にフロント側で計算を行った

## 備考
- スマホの時の対応は別ブランチでやります（このブランチから切ります）
